### PR TITLE
Fix python missing on some distros

### DIFF
--- a/ruyi/__main__.py
+++ b/ruyi/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
大部分发行版中 python 依然指向 python2