### PR TITLE
Prioritize distro-specific certificate paths

### DIFF
--- a/ruyi/utils/ssl_patch.py
+++ b/ruyi/utils/ssl_patch.py
@@ -130,12 +130,12 @@ class WellKnownCALocation(NamedTuple):
 
 
 WELL_KNOWN_CA_LOCATIONS: list[WellKnownCALocation] = [
-    # Most others
-    WellKnownCALocation("/etc/ssl/cert.pem", "/etc/ssl/certs"),
     # Debian-based distros
     WellKnownCALocation("/usr/lib/ssl/cert.pem", "/usr/lib/ssl/certs"),
     # RPM-based distros
     WellKnownCALocation("/etc/pki/tls/cert.pem", "/etc/pki/tls/certs"),
+    # Most others
+    WellKnownCALocation("/etc/ssl/cert.pem", "/etc/ssl/certs"),
 ]
 
 


### PR DESCRIPTION
It has been reported that openEuler has /etc/ssl/certs but not /etc/ssl/cert.pem, leading to certificate check failures later when connecting to github.com. Its /etc/pki/tls works fine though, so let's probe the distro-specific path before the generic one, so this distro can (finally) work.