### PR TITLE
fix: exception when news contains UTF-8 character

### DIFF
--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -450,8 +450,11 @@ class MetadataRepo:
 
         cache = NewsItemStore(rs_store)
         for f in glob.iglob("*.md", root_dir=news_dir):
-            with open(os.path.join(news_dir, f), "r") as fp:
-                contents = fp.read()
+            with open(os.path.join(news_dir, f), "r", encoding="utf-8") as fp:
+                try:
+                    contents = fp.read()
+                except UnicodeDecodeError:
+                    log.F(f"UnicodeDecodeError: {os.path.join(news_dir, f)}")
             cache.add(f, contents)  # may fail but failures are harmless
 
         cache.finalize()


### PR DESCRIPTION
当运行 `ruyi news list` 命令时，没有在 `open()` 命令中指定 `encoding`，当读出来的内容中包含 `Unicode` 字符时，会导致 `ruyi` 抛出 `UnicodeDecodeError` 的异常：

```shell
Traceback (most recent call last):
  File "/home/reki/.cache/ruyi/progcache/0.16.0/x86_64/__main__.py", line 53, in <module>
  File "/home/reki/.cache/ruyi/progcache/0.16.0/x86_64/ruyi/cli/__init__.py", line 319, in main
  File "/home/reki/.cache/ruyi/progcache/0.16.0/x86_64/ruyi/ruyipkg/news_cli.py", line 42, in cli_news_list
  File "/home/reki/.cache/ruyi/progcache/0.16.0/x86_64/ruyi/ruyipkg/repo.py", line 462, in news_store
  File "/home/reki/.cache/ruyi/progcache/0.16.0/x86_64/ruyi/ruyipkg/repo.py", line 454, in ensure_news_cache
  File "encodings/ascii.py", line 26, in decode
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe7 in position 25: ordinal not in range(128)
```

但是此问题不是必现，只有使用编译/发布的二进制才会出现。在开发环境中不会出现。

分析如下：

1. `open`函数会使用 `locale.getpreferredencoding()`的值来作为默认的 `encoding`，打印之后发现这个值在命令行中运行命令时是 `ANSI_X3.4-1968`，使用 `python` 来直接运行 `.py`文件时则是 `utf-8` ，这就是在开发环境中跑的时候不会出错的原因

2. 发现系统中的全局变量 `LC_CTYPE` 和 `LC_ALL`都是没有设定的，但是 `LANG`有设定为 `en_US.UTF-8`，可能前两个没有的情况下就会导致`locale.getpreferredencoding()`值为`ANSI_X3.4-1968` 

3. 在 `repo.py` `ensure_news_cache()` 中 `open()` 时显式指定 `encoding` 为 `utf-8` 可避免此问题

