### PR TITLE
fix: explicitly specify utf-8 for text file I/O

### DIFF
--- a/ruyi/config/news.py
+++ b/ruyi/config/news.py
@@ -6,7 +6,7 @@ class NewsReadStatusStore:
 
     def load(self) -> None:
         try:
-            with open(self._path, "r") as fp:
+            with open(self._path, "r", encoding="utf-8") as fp:
                 for line in fp:
                     self._orig_status.add(line.strip())
         except FileNotFoundError:

--- a/ruyi/mux/venv/__main__.py
+++ b/ruyi/mux/venv/__main__.py
@@ -20,7 +20,7 @@ def main() -> None:
     os.chdir(self_path)
 
     payloads = {f[:-6]: make_payload_from_file(f) for f in glob.iglob("*.jinja")}
-    with open("data.py", "w") as fp:
+    with open("data.py", "w", encoding="utf-8") as fp:
 
         def p(*args: Any) -> None:
             return print(*args, file=fp)

--- a/ruyi/ruyipkg/admin_cli.py
+++ b/ruyi/ruyipkg/admin_cli.py
@@ -59,7 +59,7 @@ def cli_admin_format_manifest(args: argparse.Namespace) -> int:
         d = dump_canonical_package_manifest_toml(pm.to_raw())
 
         dest_path = p.with_suffix(".toml")
-        with open(dest_path, "w") as fp:
+        with open(dest_path, "w", encoding="utf-8") as fp:
             fp.write(_fix_indent(d.as_string()))
 
     return 0

--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -471,7 +471,7 @@ class MetadataRepo:
         parsed_config: ProvisionerConfig | None = None
         for filename in ("config.yml", "config.yaml"):
             try:
-                with open(os.path.join(cfg_dir, filename), "r") as fp:
+                with open(os.path.join(cfg_dir, filename), "r", encoding="utf-8") as fp:
                     parsed_config = yaml.safe_load(fp)
                     break
             except FileNotFoundError:

--- a/scripts/dist-inner.py
+++ b/scripts/dist-inner.py
@@ -263,7 +263,7 @@ def set_gha_output(k: str, v: str) -> None:
         return
 
     INFO.print(f"GHA: setting output [cyan]{k}[/] to [cyan]{v}[/]")
-    with open(outfile, "a") as fp:
+    with open(outfile, "a", encoding="utf-8") as fp:
         fp.write(f"{k}={v}\n")
 
 


### PR DESCRIPTION
In cases where `LC_CTYPE` and `LANG` are invalid, the default I/O encoding for text files will become `ascii` if we're running from a Nuitka dist. While the user's configuration is likely very broken by having invalid locale settings, it's probably inappropriate to assume UTF-8 output, even though we mostly only care about that. However, simply making sure that every text file is opened with encoding explicitly set to `utf-8` can do for the time being.

Fixes: #185