### PR TITLE
Support plugin-provided Ruyi subcommands

### DIFF
--- a/ruyi/cli/builtin_commands.py
+++ b/ruyi/cli/builtin_commands.py
@@ -1,5 +1,6 @@
 from ..device import provision_cli as provision_cli
 from ..mux.venv import venv_cli as venv_cli
+from ..pluginhost import plugin_cli as plugin_cli
 from ..ruyipkg import admin_cli as admin_cli
 from ..ruyipkg import news_cli as news_cli
 from ..ruyipkg import pkg_cli as pkg_cli

--- a/ruyi/cli/cmd.py
+++ b/ruyi/cli/cmd.py
@@ -163,3 +163,15 @@ class RootCommand(
             action="store_true",
             help="Give the output in a machine-friendly format if applicable",
         )
+
+
+# Repo admin commands
+class AdminCommand(
+    RootCommand,
+    cmd="admin",
+    has_subcommands=True,
+    # https://github.com/python/cpython/issues/67037
+    # help=argparse.SUPPRESS,
+    help="(NOT FOR REGULAR USERS) Subcommands for managing Ruyi repos",
+):
+    pass

--- a/ruyi/pluginhost/paths.py
+++ b/ruyi/pluginhost/paths.py
@@ -22,6 +22,7 @@ def resolve_ruyi_load_path(
     plugin_root: pathlib.Path,
     is_for_data: bool,
     originating_file: pathlib.Path,
+    allow_host_fs_access: bool,
 ) -> pathlib.Path:
     parsed = urlparse(path)
     if parsed.params or parsed.query or parsed.fragment:
@@ -79,6 +80,22 @@ def resolve_ruyi_load_path(
                 True,
                 plugin_id=parsed.netloc,
             )
+
+        case "host":
+            if not allow_host_fs_access:
+                raise RuntimeError("the host protocol is not allowed in this context")
+
+            if not parsed.path:
+                raise RuntimeError(
+                    "empty path segment is not allowed for host:// load paths"
+                )
+
+            if parsed.netloc:
+                raise RuntimeError(
+                    "non-empty location is not allowed for host:// load paths"
+                )
+
+            return pathlib.Path(parsed.path)
 
         case _:
             raise RuntimeError(

--- a/ruyi/pluginhost/plugin_cli.py
+++ b/ruyi/pluginhost/plugin_cli.py
@@ -1,0 +1,35 @@
+import argparse
+
+from ..cli.cmd import AdminCommand
+from ..config import GlobalConfig
+from ..ruyipkg.repo import MetadataRepo
+
+
+class AdminRunPluginCommand(
+    AdminCommand,
+    cmd="run-plugin-cmd",
+    help="Run a plugin-defined command",
+):
+    @classmethod
+    def configure_args(cls, p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "cmd_name",
+            type=str,
+            metavar="COMMAND-NAME",
+            help="Command name",
+        )
+        p.add_argument(
+            "cmd_args",
+            type=str,
+            nargs="*",
+            metavar="COMMAND-ARG",
+            help="Arguments to pass to the plugin command",
+        )
+
+    @classmethod
+    def main(cls, cfg: GlobalConfig, args: argparse.Namespace) -> int:
+        cmd_name = args.cmd_name
+        cmd_args = args.cmd_args
+
+        mr = MetadataRepo(cfg)
+        return mr.run_plugin_cmd(cmd_name, cmd_args)

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -72,11 +72,11 @@ class UnsandboxedPluginHostContext(
 ):
     def make_loader(
         self,
-        plugin_root: pathlib.Path,
         originating_file: pathlib.Path,
         module_cache: MutableMapping[str, UnsandboxedModuleDict],
+        is_cmd: bool,
     ) -> BasePluginLoader[UnsandboxedModuleDict]:
-        return UnsandboxedRuyiPluginLoader(plugin_root, originating_file, module_cache)
+        return UnsandboxedRuyiPluginLoader(self, originating_file, module_cache, is_cmd)
 
     def make_evaluator(self) -> UnsandboxedTrivialEvaluator:
         return UnsandboxedTrivialEvaluator()

--- a/ruyi/ruyipkg/admin_cli.py
+++ b/ruyi/ruyipkg/admin_cli.py
@@ -10,23 +10,11 @@ from tomlkit import TOMLDocument, document, table
 from tomlkit.items import AoT, Table
 
 from .. import log
-from ..cli.cmd import RootCommand
+from ..cli.cmd import AdminCommand
 from ..config import GlobalConfig
 from . import checksum
 from .canonical_dump import dump_canonical_package_manifest_toml
 from .pkg_manifest import DistfileDeclType, PackageManifest, RestrictKind
-
-
-# Repo admin commands
-class AdminCommand(
-    RootCommand,
-    cmd="admin",
-    has_subcommands=True,
-    # https://github.com/python/cpython/issues/67037
-    # help=argparse.SUPPRESS,
-    help="(NOT FOR REGULAR USERS) Subcommands for managing Ruyi repos",
-):
-    pass
 
 
 class AdminManifestCommand(

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -12,6 +12,10 @@ class RuyiFileFixtureFactory:
     def path(self, *frags: str) -> AbstractContextManager[pathlib.Path]:
         return resources.as_file(resources.files(self.module).joinpath(*frags))
 
+    def plugin_suite(self, suite_name: str) -> AbstractContextManager[pathlib.Path]:
+        path = resources.files(self.module).joinpath("plugins_suites", suite_name)
+        return resources.as_file(path)
+
 
 @pytest.fixture
 def ruyi_file() -> RuyiFileFixtureFactory:

--- a/tests/fixtures/plugins_suites/with_/foo/mod.star
+++ b/tests/fixtures/plugins_suites/with_/foo/mod.star
@@ -1,0 +1,17 @@
+RUYI = ruyi_plugin_rev(1)
+
+
+def fn1(mgr):
+    def _with_inner(obj):
+        return obj * 2
+    return RUYI.with_(mgr, _with_inner)
+
+
+def fn2(mgr):
+    def _with_inner(obj):
+        return mgr.NoNeXiStEnT
+    return RUYI.with_(mgr, _with_inner)
+
+
+def fn3(mgr, py_fn):
+    return RUYI.with_(mgr, py_fn)

--- a/tests/pluginhost/test_api.py
+++ b/tests/pluginhost/test_api.py
@@ -1,0 +1,64 @@
+from contextlib import AbstractContextManager
+from types import TracebackType
+
+import pytest
+import xingque
+
+from ruyi.pluginhost import PluginHostContext
+
+from ..fixtures import RuyiFileFixtureFactory
+
+
+def test_api_with_(
+    ruyi_file: RuyiFileFixtureFactory,
+) -> None:
+    class MockContextManager(AbstractContextManager[int]):
+        def __init__(self) -> None:
+            self.entered = 0
+            self.exited = 0
+
+        def __enter__(self) -> int:
+            self.entered += 1
+            return 233
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> bool | None:
+            self.exited += 1
+            return None
+
+    with ruyi_file.plugin_suite("with_") as plugin_root:
+        phctx = PluginHostContext(plugin_root)
+        ev = xingque.Evaluator()
+
+        fn1 = phctx.get_from_plugin("foo", "fn1")
+        assert fn1 is not None
+        cm1 = MockContextManager()
+        ret1 = ev.eval_function(fn1, cm1)
+        assert cm1.entered == 1
+        assert cm1.exited == 1
+        assert ret1 == 466
+
+        # even when the Starlark side panics, the context manager semantics
+        # shall remain enforced
+        fn2 = phctx.get_from_plugin("foo", "fn2")
+        assert fn2 is not None
+        cm2 = MockContextManager()
+        with pytest.raises(RuntimeError):
+            ev.eval_function(fn2, cm2)
+        assert cm2.entered == 1
+        assert cm2.exited == 1
+
+        def inner_fn3(x: int) -> int:
+            return x - 233
+
+        fn3 = phctx.get_from_plugin("foo", "fn3")
+        assert fn3 is not None
+        cm3 = MockContextManager()
+        ret3 = ev.eval_function(fn3, cm3, inner_fn3)
+        assert cm3.entered == 1
+        assert cm3.exited == 1
+        assert ret3 == 0

--- a/tests/pluginhost/test_api.py
+++ b/tests/pluginhost/test_api.py
@@ -2,7 +2,6 @@ from contextlib import AbstractContextManager
 from types import TracebackType
 
 import pytest
-import xingque
 
 from ruyi.pluginhost import PluginHostContext
 
@@ -31,8 +30,8 @@ def test_api_with_(
             return None
 
     with ruyi_file.plugin_suite("with_") as plugin_root:
-        phctx = PluginHostContext(plugin_root)
-        ev = xingque.Evaluator()
+        phctx = PluginHostContext.new(plugin_root)
+        ev = phctx.make_evaluator()
 
         fn1 = phctx.get_from_plugin("foo", "fn1")
         assert fn1 is not None
@@ -42,12 +41,12 @@ def test_api_with_(
         assert cm1.exited == 1
         assert ret1 == 466
 
-        # even when the Starlark side panics, the context manager semantics
+        # even when the plugin side panics, the context manager semantics
         # shall remain enforced
         fn2 = phctx.get_from_plugin("foo", "fn2")
         assert fn2 is not None
         cm2 = MockContextManager()
-        with pytest.raises(RuntimeError):
+        with pytest.raises((RuntimeError, AttributeError)):
             ev.eval_function(fn2, cm2)
         assert cm2.entered == 1
         assert cm2.exited == 1


### PR DESCRIPTION
In an experiment to allow more logic to reside outside of `ruyi` proper, for increasing development agility even more.

This is not currently meant to be stable; exact UX (or even presence) of the feature is not guaranteed for now.