### PR TITLE
Make `ruyi` config datetimes timezone-aware

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -891,6 +891,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2024.2"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1022,4 +1033,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "78a330072a169812f0192eefe8fc955bd362ed0c6d64dfe4a0a2cf931a949952"
+content-hash = "9c530aa0b089259b1388da31f33c6d036dded373eed6f35672466f0e229ee667"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ rich = ">=11.2.0"
 semver = ">=2.10"
 tomlkit = ">=0.9"
 tomli = { version = ">=1.2", python = "<3.11" }
+tzdata = { version = "^2024.2", platform = "win32" }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.9.0"

--- a/ruyi/config/errors.py
+++ b/ruyi/config/errors.py
@@ -48,7 +48,7 @@ class InvalidConfigValueTypeError(TypeError):
 class InvalidConfigValueError(ValueError):
     def __init__(
         self,
-        key: str | Sequence[str],
+        key: str | Sequence[str] | type,
         val: object | None,
     ) -> None:
         super().__init__()
@@ -56,7 +56,9 @@ class InvalidConfigValueError(ValueError):
         self._val = val
 
     def __str__(self) -> str:
-        return f"invalid value for config key {self._key}: {self._val}"
+        if isinstance(self._key, type):
+            return f"invalid config value for type {self._key}: {self._val}"
+        return f"invalid config value for key {self._key}: {self._val}"
 
     def __repr__(self) -> str:
         return f"InvalidConfigValueError({self._key:!r}, {self._val:!r})"

--- a/ruyi/config/schema.py
+++ b/ruyi/config/schema.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 from typing import Final, Sequence
 
 from .errors import (
@@ -153,7 +154,11 @@ def encode_value(v: object) -> str:
     elif isinstance(v, datetime.datetime):
         if v.tzinfo is None:
             raise ValueError("only timezone-aware datetimes are supported for safety")
-        return v.isoformat()
+        s = v.isoformat()
+        if s.endswith("+00:00"):
+            # use the shorter 'Z' suffix for UTC
+            return f"{s[:-6]}Z"
+        return s
     else:
         raise NotImplementedError(f"invalid type for config value: {type(v)}")
 
@@ -182,6 +187,10 @@ def decode_value(
     elif expected_type is str:
         return val
     elif expected_type is datetime.datetime:
+        if sys.version_info < (3, 11) and val.endswith("Z"):
+            # datetime.fromisoformat() did not support the 'Z' suffix until
+            # Python 3.11
+            val = f"{val[:-1]}+00:00"
         v = datetime.datetime.fromisoformat(val)
         return v.astimezone() if v.tzinfo is None else v
     else:

--- a/ruyi/config/schema.py
+++ b/ruyi/config/schema.py
@@ -159,13 +159,17 @@ def encode_value(v: object) -> str:
 
 
 def decode_value(
-    key: str | Sequence[str],
+    key: str | Sequence[str] | type,
     val: str,
 ) -> object:
     """Decodes the given string representation of a config value into a Python
     value, directed by type information implied by the config key."""
 
-    expected_type = get_expected_type_for_config_key(key)
+    if isinstance(key, type):
+        expected_type = key
+    else:
+        expected_type = get_expected_type_for_config_key(key)
+
     if expected_type is bool:
         if val in ("true", "yes", "1"):
             return True

--- a/ruyi/config/schema.py
+++ b/ruyi/config/schema.py
@@ -151,6 +151,8 @@ def encode_value(v: object) -> str:
     elif isinstance(v, str):
         return v
     elif isinstance(v, datetime.datetime):
+        if v.tzinfo is None:
+            raise ValueError("only timezone-aware datetimes are supported for safety")
         return v.isoformat()
     else:
         raise NotImplementedError(f"invalid type for config value: {type(v)}")
@@ -176,6 +178,7 @@ def decode_value(
     elif expected_type is str:
         return val
     elif expected_type is datetime.datetime:
-        return datetime.datetime.fromisoformat(val)
+        v = datetime.datetime.fromisoformat(val)
+        return v.astimezone() if v.tzinfo is None else v
     else:
         raise NotImplementedError(f"invalid type for config value: {expected_type}")

--- a/ruyi/telemetry/telemetry_cli.py
+++ b/ruyi/telemetry/telemetry_cli.py
@@ -30,7 +30,7 @@ class TelemetryConsentCommand(
 
     @classmethod
     def main(cls, cfg: config.GlobalConfig, args: argparse.Namespace) -> int:
-        now = datetime.datetime.now()
+        now = datetime.datetime.now().astimezone()
         with ConfigEditor.work_on_user_local_config(cfg) as ed:
             ed.set_value((schema.SECTION_TELEMETRY, schema.KEY_TELEMETRY_MODE), "on")
             ed.set_value(

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,0 +1,61 @@
+import datetime
+
+import pytest
+
+from ruyi.config.errors import InvalidConfigValueError
+from ruyi.config.schema import decode_value, encode_value
+
+
+def test_decode_value_bool() -> None:
+    assert decode_value("installation.externally_managed", "true") is True
+    assert decode_value("installation.externally_managed", "false") is False
+    assert decode_value("installation.externally_managed", "yes") is True
+    assert decode_value("installation.externally_managed", "no") is False
+    assert decode_value("installation.externally_managed", "1") is True
+    assert decode_value("installation.externally_managed", "0") is False
+    with pytest.raises(InvalidConfigValueError):
+        decode_value("installation.externally_managed", "invalid")
+    with pytest.raises(InvalidConfigValueError):
+        decode_value("installation.externally_managed", "x")
+    with pytest.raises(InvalidConfigValueError):
+        decode_value("installation.externally_managed", "True")
+
+
+def test_decode_value_str() -> None:
+    assert decode_value("repo.branch", "main") == "main"
+
+
+def test_decode_value_datetime() -> None:
+    tz_aware_dt = datetime.datetime(2024, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    assert (
+        decode_value("telemetry.upload_consent", "2024-12-01T12:00:00Z") == tz_aware_dt
+    )
+
+    # naive datetimes are decoded using the implicit local timezone
+    decode_value("telemetry.upload_consent", "2024-12-01T12:00:00")
+
+
+def test_encode_value_bool() -> None:
+    assert encode_value(True) == "true"
+    assert encode_value(False) == "false"
+
+
+def test_encode_value_int() -> None:
+    assert encode_value(123) == "123"
+
+
+def test_encode_value_str() -> None:
+    assert encode_value("") == ""
+    assert encode_value("main") == "main"
+
+
+def test_encode_value_datetime() -> None:
+    tz_aware_dt = datetime.datetime(2024, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    assert encode_value(tz_aware_dt) == "2024-12-01T12:00:00+00:00"
+
+    # specifically check that naive datetimes are rejected
+    tz_naive_dt = datetime.datetime(2024, 12, 1, 12, 0, 0)
+    with pytest.raises(
+        ValueError, match="only timezone-aware datetimes are supported for safety"
+    ):
+        encode_value(tz_naive_dt)

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -8,21 +8,24 @@ from ruyi.config.schema import decode_value, encode_value
 
 def test_decode_value_bool() -> None:
     assert decode_value("installation.externally_managed", "true") is True
-    assert decode_value("installation.externally_managed", "false") is False
-    assert decode_value("installation.externally_managed", "yes") is True
-    assert decode_value("installation.externally_managed", "no") is False
-    assert decode_value("installation.externally_managed", "1") is True
-    assert decode_value("installation.externally_managed", "0") is False
+
+    assert decode_value(bool, "true") is True
+    assert decode_value(bool, "false") is False
+    assert decode_value(bool, "yes") is True
+    assert decode_value(bool, "no") is False
+    assert decode_value(bool, "1") is True
+    assert decode_value(bool, "0") is False
     with pytest.raises(InvalidConfigValueError):
-        decode_value("installation.externally_managed", "invalid")
+        decode_value(bool, "invalid")
     with pytest.raises(InvalidConfigValueError):
-        decode_value("installation.externally_managed", "x")
+        decode_value(bool, "x")
     with pytest.raises(InvalidConfigValueError):
-        decode_value("installation.externally_managed", "True")
+        decode_value(bool, "True")
 
 
 def test_decode_value_str() -> None:
     assert decode_value("repo.branch", "main") == "main"
+    assert decode_value(str, "main") == "main"
 
 
 def test_decode_value_datetime() -> None:
@@ -30,9 +33,10 @@ def test_decode_value_datetime() -> None:
     assert (
         decode_value("telemetry.upload_consent", "2024-12-01T12:00:00Z") == tz_aware_dt
     )
+    assert decode_value(datetime.datetime, "2024-12-01T12:00:00Z") == tz_aware_dt
 
     # naive datetimes are decoded using the implicit local timezone
-    decode_value("telemetry.upload_consent", "2024-12-01T12:00:00")
+    decode_value(datetime.datetime, "2024-12-01T12:00:00")
 
 
 def test_encode_value_bool() -> None:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -34,6 +34,7 @@ def test_decode_value_datetime() -> None:
         decode_value("telemetry.upload_consent", "2024-12-01T12:00:00Z") == tz_aware_dt
     )
     assert decode_value(datetime.datetime, "2024-12-01T12:00:00Z") == tz_aware_dt
+    assert decode_value(datetime.datetime, "2024-12-01T12:00:00+00:00") == tz_aware_dt
 
     # naive datetimes are decoded using the implicit local timezone
     decode_value(datetime.datetime, "2024-12-01T12:00:00")
@@ -55,7 +56,7 @@ def test_encode_value_str() -> None:
 
 def test_encode_value_datetime() -> None:
     tz_aware_dt = datetime.datetime(2024, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    assert encode_value(tz_aware_dt) == "2024-12-01T12:00:00+00:00"
+    assert encode_value(tz_aware_dt) == "2024-12-01T12:00:00Z"
 
     # specifically check that naive datetimes are rejected
     tz_naive_dt = datetime.datetime(2024, 12, 1, 12, 0, 0)


### PR DESCRIPTION
* ensure `ruyi`-recorded config datetimes are timezone-aware
* make `ruyi telemetry consent` write the consent time including the current local time zone