### PR TITLE
Bump Python to 3.13 for Windows builds too

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -139,7 +139,7 @@ jobs:
           # don't let the ">=" directive bump the Python version without letting
           # us know
           # python-version-file: pyproject.toml
-          python-version: '3.12'
+          python-version: '3.13'
           cache: poetry
 
       - name: Cache/restore Nuitka clcache contents


### PR DESCRIPTION
This was forgotten during the last bump for Linux.