### PR TITLE
Workaround an oversight in some distfiles' declaration of restrictions

### DIFF
--- a/ruyi/ruyipkg/canonical_dump.py
+++ b/ruyi/ruyipkg/canonical_dump.py
@@ -160,6 +160,10 @@ def dump_distfile_entry(x: DistfileDeclType) -> Table:
         # from using 2-space indentation for the array items for now.
         y.add("urls", str_array([str(i) for i in x["urls"]], multiline=True))
     if r := x.get("restrict"):
+        # If `restrict` is a string, convert it to a list, fixing a common
+        # oversight in package manifests.
+        if isinstance(r, str):
+            r = [r]
         y.add("restrict", [str(i) for i in r])
     if f := x.get("fetch_restriction"):
         y.add("fetch_restriction", dump_fetch_restriction(f))

--- a/ruyi/ruyipkg/pkg_manifest.py
+++ b/ruyi/ruyipkg/pkg_manifest.py
@@ -219,6 +219,11 @@ class DistfileDecl:
 
     def is_restricted(self, kind: RestrictKind) -> bool:
         if restricts := self._data.get("restrict"):
+            # account for a common oversight in some existing manifests where
+            # the field was specified as a string instead of a list, in case the
+            # user has not yet synced their repo
+            if isinstance(restricts, str):
+                return kind == restricts
             return kind in restricts
         return False
 

--- a/tests/fixtures/ruyipkg_suites/format_manifest/distfile-restrict.after.toml
+++ b/tests/fixtures/ruyipkg_suites/format_manifest/distfile-restrict.after.toml
@@ -1,0 +1,31 @@
+format = "v1"
+
+[metadata]
+desc = "Official WCH MounRiver Studio GNU Toolchain (bare-metal, GCC 12.x, prebuilt by WCH)"
+vendor = { name = "WCH", eula = "" }
+
+[[distfiles]]
+name = "MRS_Toolchain_Linux_x64_V210.tar.xz"
+size = 548823504
+prefixes_to_unpack = ["RISC-V Embedded GCC12"]
+urls = [
+  "http://file-oss.mounriver.com/tools/MRS_Toolchain_Linux_x64_V210.tar.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "5431c040cb67cf619fd18d003ed9497a1995f59329b7f51d985dcc8013eff236"
+sha512 = "9aa07d4b5e173ec5f661d851f60ec88085a458188afdf21e265e47f2ef9df5ff623d0158173a9fb1620a72945c7f3dfc6dfadfc3661dee5184ba9392a8ee90a4"
+
+[[binary]]
+host = "x86_64"
+distfiles = ["MRS_Toolchain_Linux_x64_V210.tar.xz"]
+
+[toolchain]
+target = "riscv32-wch-elf"
+quirks = ["wch"]
+components = [
+  { name = "binutils", version = "2.38" },
+  { name = "gcc", version = "12.2.0" },
+  { name = "gdb", version = "12.1" },
+]

--- a/tests/fixtures/ruyipkg_suites/format_manifest/distfile-restrict.before.toml
+++ b/tests/fixtures/ruyipkg_suites/format_manifest/distfile-restrict.before.toml
@@ -1,0 +1,31 @@
+format = "v1"
+
+[metadata]
+desc = "Official WCH MounRiver Studio GNU Toolchain (bare-metal, GCC 12.x, prebuilt by WCH)"
+vendor = { name = "WCH", eula = "" }
+
+[[distfiles]]
+name = "MRS_Toolchain_Linux_x64_V210.tar.xz"
+size = 548823504
+urls = [
+  "http://file-oss.mounriver.com/tools/MRS_Toolchain_Linux_x64_V210.tar.xz",
+]
+restrict = "mirror"
+prefixes_to_unpack = ["RISC-V Embedded GCC12"]
+
+[distfiles.checksums]
+sha256 = "5431c040cb67cf619fd18d003ed9497a1995f59329b7f51d985dcc8013eff236"
+sha512 = "9aa07d4b5e173ec5f661d851f60ec88085a458188afdf21e265e47f2ef9df5ff623d0158173a9fb1620a72945c7f3dfc6dfadfc3661dee5184ba9392a8ee90a4"
+
+[[binary]]
+host = "x86_64"
+distfiles = ["MRS_Toolchain_Linux_x64_V210.tar.xz"]
+
+[toolchain]
+target = "riscv32-wch-elf"
+flavors = ["wch"]
+components = [
+  { name = "binutils", version = "2.38" },
+  { name = "gcc", version = "12.2.0" },
+  { name = "gdb", version = "12.1" },
+]


### PR DESCRIPTION
Treat the likes of `restrict = "mirror"` as `restrict = ["..."]`, and automatically fix it during `ruyi admin format-manifest`. This behavior shall remain undocumented to prevent it from proliferating.