### PR TITLE
Add alias `ruyi device flash` for `ruyi device provision`

### DIFF
--- a/ruyi/device/provision_cli.py
+++ b/ruyi/device/provision_cli.py
@@ -22,6 +22,7 @@ class DeviceCommand(
 class DeviceProvisionCommand(
     DeviceCommand,
     cmd="provision",
+    aliases=["flash"],
     help="Interactively initialize a device for development",
 ):
     @classmethod


### PR DESCRIPTION
Many users reported difficulties with the word "provision", and suggested "flash" as an alternative. While what we do is expected to be more than just "flashing" at least in the roadmap, it is the case for now, and "flash" is easier for non-English speakers. So just add an alias to reduce typing and confusion for those.

Link: https://ruyisdk.cn/t/topic/506