### PR TITLE
Speed up riscv64 dist builds

### DIFF
--- a/scripts/dist-gha.sh
+++ b/scripts/dist-gha.sh
@@ -9,6 +9,7 @@ export RUYI_DIST_BUILD_DIR=/github/workspace/build
 export RUYI_DIST_CACHE_DIR=/github/workspace/build-cache/ruyi-dist-cache
 export RUYI_DIST_INNER_CONTAINERIZED=x
 export RUYI_DIST_INNER=x
+export RUYI_DIST_ADDITIONAL_INDEX_URL=https://mirror.iscas.ac.cn/ruyisdk/dist/python-wheels/simple/
 "$MY_DIR"/dist.sh "$@"
 ret=$?
 


### PR DESCRIPTION
And install cffi from the index too to save time.

For now the cffi build is taken from the https://gitlab.com/riseproject/python/wheel_builder project.