### PR TITLE
Tell the user repo update is in progress before syncing

### DIFF
--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -306,13 +306,15 @@ class MetadataRepo(ProvidesPackageManifests):
         return self.repo
 
     def sync(self) -> None:
+        self._gc.logger.I("updating the package repository")
+
         repo = self.ensure_git_repo()
 
         # only manage the repo settings on the user's behalf if the user
         # has not overridden the repo directory themselves
         allow_auto_management = self._gc.override_repo_dir is None
 
-        return pull_ff_or_die(
+        pull_ff_or_die(
             self.logger,
             repo,
             "origin",
@@ -320,6 +322,8 @@ class MetadataRepo(ProvidesPackageManifests):
             self.branch,
             allow_auto_management=allow_auto_management,
         )
+
+        self._gc.logger.I("package repository is updated")
 
     @property
     def global_config(self) -> "GlobalConfig":


### PR DESCRIPTION
We can alert the user of possible connectivity issues if the sync doesn't finish after a while, but telling the user syncing is in progress is going to help.

Fixes: #352