### PR TITLE
Really fix repo cloning notification

### DIFF
--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -284,7 +284,8 @@ class MetadataRepo(ProvidesPackageManifests):
             self.repo = Repository(self.root)
             return self.repo
 
-        self.logger.D(f"{self.root} does not exist, cloning from {self.remote}")
+        self.logger.I(f"the package repository does not exist at [yellow]{self.root}[/]")
+        self.logger.I(f"cloning from [cyan link={self.remote}]{self.remote}[/]")
 
         with RemoteGitProgressIndicator() as pr:
             repo = clone_repository(


### PR DESCRIPTION
Previously #358 took care of `sync()`, but implicit cloning comes from `ensure_git_repo()` and not `sync()`.

Fixes: #352