### PR TITLE
Fix inconsistency in handling overridden local repo path

### DIFF
--- a/ruyi/config/__init__.py
+++ b/ruyi/config/__init__.py
@@ -280,8 +280,21 @@ class GlobalConfig:
     def override_pm_telemetry_url(self) -> str | None:
         return self._telemetry_pm_telemetry_url
 
+    @cached_property
+    def default_repo_dir(self) -> str:
+        return os.path.join(self.cache_root, "packages-index")
+
     def get_repo_dir(self) -> str:
-        return self.override_repo_dir or os.path.join(self.cache_root, "packages-index")
+        return self.override_repo_dir or self.default_repo_dir
+
+    @cached_property
+    def have_overridden_repo_dir(self) -> bool:
+        if not self.override_repo_dir:
+            return False
+        override_path = pathlib.Path(self.override_repo_dir)
+        default_path = pathlib.Path(self.default_repo_dir)
+        # we don't use samefile() here because the path may not exist
+        return override_path.resolve() != default_path.resolve()
 
     def get_repo_url(self) -> str:
         return self.override_repo_url or DEFAULT_REPO_URL

--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -315,7 +315,7 @@ class MetadataRepo(ProvidesPackageManifests):
 
         # only manage the repo settings on the user's behalf if the user
         # has not overridden the repo directory themselves
-        allow_auto_management = self._gc.override_repo_dir is None
+        allow_auto_management = not self._gc.have_overridden_repo_dir
 
         pull_ff_or_die(
             self.logger,


### PR DESCRIPTION
While the #372 description is a bit unclear, there actually is inconsistency between the computation of local repo path and the "customization" detection. The former only looks at truthiness of override_repo_dir, making an empty string equivalent to an unset value, while the latter is a strict None check treating an empty string differently. Make them consistent by moving the logic into GlobalConfig.

While at it, treat a "set but same as default" repo path setting as "not customized", because the path is considered to be managed by us anyway, and that the user may not be aware of the difference between "unsetting a value" and "setting the default".

See: #372