### PR TITLE
Make manual operation prompts really stand out

### DIFF
--- a/ruyi/device/provision.py
+++ b/ruyi/device/provision.py
@@ -276,7 +276,7 @@ We are about to:
                 """
 Some flashing steps require the use of fastboot, in which case you should
 ensure the target device is showing up in [yellow]fastboot devices[/] output.
-Please confirm it yourself before the flashing begins.
+Please [bold red]confirm it yourself before continuing[/].
 """
             )
             if not user_input.ask_for_yesno_confirmation(

--- a/ruyi/utils/git.py
+++ b/ruyi/utils/git.py
@@ -119,7 +119,7 @@ def pull_ff_or_die(
             logger.I(f"repository:          [yellow]{repo_path}[/]")
             logger.I(f"expected remote URL: [yellow]{remote_url}[/]")
             logger.I(f"actual remote URL:   [yellow]{remote.url}[/]")
-            logger.I("please fix the repo settings manually")
+            logger.I("please [bold red]fix the repo settings manually[/]")
             raise SystemExit(1)
 
         logger.D(


### PR DESCRIPTION
As suggested in team conversation when working on #372, make those prompts explicitly asking the user to do something stand out by showing them in bold red.

Suggested-by: Wei Wu <wuwei2016@iscas.ac.cn>