### PR TITLE
Fix repo remote URL management

### DIFF
--- a/ruyi/utils/git.py
+++ b/ruyi/utils/git.py
@@ -125,7 +125,9 @@ def pull_ff_or_die(
         logger.D(
             f"updating url of remote {remote_name} from {remote.url} to {remote_url}"
         )
-        repo.remotes.set_url("origin", remote_url)
+        repo.remotes.set_url(remote_name, remote_url)
+        # this needs manual refreshing
+        remote = repo.remotes[remote_name]
 
     logger.D("fetching")
     try:


### PR DESCRIPTION
Fixes two problems:

* the name of the to-be-updated remote being incorrectly hard-coded as "origin",
* the new remote URL not taking effect immediately after the update.

Fixes: #373