### PR TITLE
Fix `ruyi clean --all` not removing ruyipkg state

### DIFF
--- a/ruyi/cli/self_cli.py
+++ b/ruyi/cli/self_cli.py
@@ -131,12 +131,16 @@ class SelfCleanCommand(
         _do_reset(
             cfg,
             quiet=quiet,
+            # state-related
+            all_state=all,
+            news_read_status=news_read_status,
+            telemetry=telemetry,
+            # cache-related
+            all_cache=all,
             distfiles=distfiles,
             installed_pkgs=installed_pkgs,
-            news_read_status=news_read_status,
             progcache=progcache,
             repo=repo,
-            telemetry=telemetry,
         )
 
         return 0
@@ -233,6 +237,7 @@ def _do_reset(
     if installed_pkgs:
         status("removing installed packages")
         shutil.rmtree(cfg.data_root, True)
+        cfg.ruyipkg_global_state.purge_installation_info()
 
     # do not record any telemetry data if we're purging it
     if all_state or telemetry:

--- a/ruyi/ruyipkg/state.py
+++ b/ruyi/ruyipkg/state.py
@@ -76,6 +76,16 @@ class RuyipkgGlobalStateStore:
         """Ensure the state directory exists."""
         self.root.mkdir(parents=True, exist_ok=True)
 
+    def purge_installation_info(self) -> None:
+        """Purge installation records."""
+        self._installs_file.unlink(missing_ok=True)
+        self._installs_cache = None
+        # if the state dir is empty, remove it
+        try:
+            self.root.rmdir()
+        except OSError:
+            pass
+
     def _load_installs(self) -> dict[str, PackageInstallationInfo]:
         """Load installation records from disk."""
         if self._installs_cache is not None:


### PR DESCRIPTION
We weren't passing the `--all` flag to the helper function's `all_state` or `all_cache` parameters before.

Fixes: #383