### PR TITLE
docs: add new used vendor id spacemit

### DIFF
--- a/docs/naming-of-devices-and-images.md
+++ b/docs/naming-of-devices-and-images.md
@@ -30,6 +30,7 @@ RuyiSDK 体系内的命名作出一些约定。
 | `pine64` | Pine64 |
 | `sifive` | SiFive |
 | `sipeed` | Sipeed |
+| `spacemit` | SpacemiT |
 | `starfive` | StarFive |
 | `wch` | WinChipHead |
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Include 'spacemit' mapping to 'SpacemiT' in naming-of-devices-and-images.md