### PR TITLE
Fix packaging of `rich` in the onefile distribution

### DIFF
--- a/scripts/dist-inner.py
+++ b/scripts/dist-inner.py
@@ -100,6 +100,7 @@ def main() -> None:
         "--include-package=pygments.formatters",
         "--include-package=pygments.lexers",
         "--include-package=pygments.styles",
+        "--include-package=rich._unicode_data",
         "--include-package=_cffi_backend",  # https://github.com/Nuitka/Nuitka/issues/2505
         "--windows-icon-from-ico=resources/ruyi.ico",
         "--show-scons",


### PR DESCRIPTION
Fixes: #428

## Summary by Sourcery

Build:
- Update the one-file build script to bundle the rich._unicode_data package with the application.