### PR TITLE
Do not drop `strip_components = 0` in `ruyi admin format-manifest`

### DIFF
--- a/ruyi/ruyipkg/canonical_dump.py
+++ b/ruyi/ruyipkg/canonical_dump.py
@@ -150,9 +150,9 @@ def dump_distfile_entry(x: DistfileDeclType) -> Table:
     if v := x.get("unpack"):
         y.add("unpack", string(v))
     y.add("size", x["size"])
-    if s := x.get("strip_components"):
-        if s != 1:
-            y.add("strip_components", s)
+    s = x.get("strip_components")
+    if s is not None and s != 1:
+        y.add("strip_components", s)
     if p := x.get("prefixes_to_unpack"):
         y.add("prefixes_to_unpack", str_array(p, multiline=len(p) > 1))
     if "urls" in x:

--- a/tests/fixtures/ruyipkg_suites/format_manifest/strip-components-zero.after.toml
+++ b/tests/fixtures/ruyipkg_suites/format_manifest/strip-components-zero.after.toml
@@ -1,0 +1,30 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20260114"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20260114"
+
+[[distfiles]]
+name = "2026-01-14-16-03-d4003f.tar.xz"
+size = 171913924
+strip_components = 0
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20260114/2026-01-14-16-03-d4003f.tar.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d6478170e923615ca28c97592a2c68a67971e6d07fcb967371b58791938698dd"
+sha512 = "63b2ba457c227f1f171af669d80663d2b92a7de1b23cc7975cba0a2b3924d50608b71cf6978735a981b666da709d5b30103124ab9a37fe49e6080ca826c5e475"
+
+[blob]
+distfiles = [
+  "2026-01-14-16-03-d4003f.tar.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2026-01-14-16-03-d4003f.img"

--- a/tests/fixtures/ruyipkg_suites/format_manifest/strip-components-zero.before.toml
+++ b/tests/fixtures/ruyipkg_suites/format_manifest/strip-components-zero.before.toml
@@ -1,0 +1,28 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20260114"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20260114"
+
+[[distfiles]]
+name = "2026-01-14-16-03-d4003f.tar.xz"
+size = 171913924
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20260114/2026-01-14-16-03-d4003f.tar.xz",
+]
+restrict = ["mirror"]
+strip_components = 0
+
+[distfiles.checksums]
+sha256 = "d6478170e923615ca28c97592a2c68a67971e6d07fcb967371b58791938698dd"
+sha512 = "63b2ba457c227f1f171af669d80663d2b92a7de1b23cc7975cba0a2b3924d50608b71cf6978735a981b666da709d5b30103124ab9a37fe49e6080ca826c5e475"
+
+[blob]
+distfiles = ["2026-01-14-16-03-d4003f.tar.xz"]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2026-01-14-16-03-d4003f.img"


### PR DESCRIPTION
The walrus operator pattern `if s := x.get("strip_components")` treated the value 0 as falsy, causing `strip_components = 0` to be silently dropped by `ruyi admin format-manifest`, making it impossible to have such manifests canonically formatted.

Change the condition to an explicit `is not None` check so that all non-default values, including 0, are preserved in the formatted output.

Fixes: #430

## Summary by Sourcery

Preserve explicitly specified non-default strip_components values when formatting manifest distfile entries.

Bug Fixes:
- Ensure strip_components = 0 is retained instead of being dropped during canonical manifest formatting.

Tests:
- Add before/after fixture manifests to verify strip_components = 0 survives format-manifest processing.