### PR TITLE
feat(ruyipkg): add porcelain support to 'ruyi list profile'

### DIFF
--- a/ruyi/ruyipkg/profile.py
+++ b/ruyi/ruyipkg/profile.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 from ..pluginhost.ctx import PluginHostContext
 from ..pluginhost.traits import SupportsEvalFunction
+from ..utils.porcelain import PorcelainEntity, PorcelainEntityType, PorcelainOutput
 from .entity_provider import BaseEntityProvider
 from .pkg_manifest import EmulatorFlavor
 
@@ -222,6 +223,20 @@ class ProfileProxy:
     ) -> dict[str, str] | None:
         return self._provider.get_env_config_for_emu_flavor(self._id, flavor, sysroot)
 
+    def to_porcelain(self) -> "PorcelainProfileListOutputV1":
+        return {
+            "ty": PorcelainEntityType.ProfileListOutputV1,
+            "id": self._id,
+            "arch": self._arch,
+            "need_quirks": sorted(self.need_quirks),
+        }
+
+
+class PorcelainProfileListOutputV1(PorcelainEntity):
+    id: str
+    arch: str
+    need_quirks: list[str]
+
 
 #
 # Protocols
@@ -354,3 +369,12 @@ def _load_profile_v1_entities_for_arch(
             "related": relations,
         }
     return result
+
+
+def do_list_profiles_porcelain(provider: ProvidesProfiles) -> int:
+    """Output the list of profiles in porcelain format."""
+    with PorcelainOutput() as po:
+        for arch in provider.get_supported_arches():
+            for p in provider.iter_profiles_for_arch(arch):
+                po.emit(p.to_porcelain())
+    return 0

--- a/ruyi/ruyipkg/profile_cli.py
+++ b/ruyi/ruyipkg/profile_cli.py
@@ -20,8 +20,13 @@ class ListProfilesCommand(
 
     @classmethod
     def main(cls, cfg: "GlobalConfig", args: argparse.Namespace) -> int:
+        from .profile import do_list_profiles_porcelain
+
         logger = cfg.logger
         mr = cfg.repo
+
+        if cfg.is_porcelain:
+            return do_list_profiles_porcelain(mr)
 
         for arch in mr.get_supported_arches():
             for p in mr.iter_profiles_for_arch(arch):

--- a/ruyi/utils/porcelain.py
+++ b/ruyi/utils/porcelain.py
@@ -15,6 +15,7 @@ if sys.version_info >= (3, 11):
         NewsItemV1 = "newsitem-v1"
         PkgListOutputV1 = "pkglistoutput-v1"
         EntityListOutputV1 = "entitylistoutput-v1"
+        ProfileListOutputV1 = "profilelistoutput-v1"
 
 else:
 
@@ -23,6 +24,7 @@ else:
         NewsItemV1 = "newsitem-v1"
         PkgListOutputV1 = "pkglistoutput-v1"
         EntityListOutputV1 = "entitylistoutput-v1"
+        ProfileListOutputV1 = "profilelistoutput-v1"
 
 
 class PorcelainEntity(TypedDict):


### PR DESCRIPTION
added `--porcelain` support to CLI command `ruyi list profile` for `ruyisdk-vscode-extension` and other downstream programmatic usages

having native support of `--porcelain` would prevent issues such as https://github.com/ruyisdk/ruyisdk-vscode-extension/issues/122 in the future and eliminate the need for fragile regex workarounds like https://github.com/ruyisdk/ruyisdk-vscode-extension/pull/118/changes/2e6f2c668ee158c5782b7deef455b0bfbc403739

## Summary by Sourcery

Add porcelain-mode support for the `ruyi list profile` CLI to provide structured, machine-readable profile listings.

New Features:
- Introduce a porcelain output variant for listing profiles, including profile ID, architecture, and required quirks.
- Extend the profile listing CLI command to detect porcelain mode and emit structured porcelain entities accordingly.

Enhancements:
- Expand the shared porcelain entity type enum to cover profile list output for consistent downstream consumption.