### PR TITLE
Support building packages through `ruyi admin build-package`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,7 @@
 * [Ruyi 软件源结构定义](./repo-structure.md)
     * [多软件源支持（Overlay 架构）设计文档](./multi-repo-design.md)
     * [多软件源支持（用户文档）](./multi-repo.md)
+
+## 软件包构建
+
+* [构建配方（Build Recipe）设计文档](./build-recipes-design.md)

--- a/docs/build-recipes-design.md
+++ b/docs/build-recipes-design.md
@@ -1,0 +1,215 @@
+# 构建配方（Build Recipe）设计文档
+
+## 背景与动机
+
+当前 RuyiSDK 软件包的构建流程事实上分散在若干独立的仓库与脚本中：
+
+* `packages-index` 保存面向终端用户的软件包清单（manifest），是一份"已构建产物的目录"。
+* `ruyici` 仓库保存实际的构建脚本：每个目标软件包对应一组 `ruyi-build-*` 外层脚本（Docker 封装层）与 `ruyi-build-*-inner` 内层脚本（容器内实际构建逻辑），以及一批特定驱动所需的配置文件（`toolchain-configs/`、`qemu-configs/`、`llvm-configs/` 等）与补丁（`toolchain-patches/`）。
+* 构建操作者（packager）需要凭记忆或参考 README 才知道"构建 `toolchain/gnu-plct` 0.20231118.0 这个版本对应的命令是 `./ruyi-build-ctng ./toolchain-configs/gnu-plct/host-amd64.defconfig`"。这一"部落知识"从未被系统化。
+
+本设计的目的是：
+
+1. 将"如何构建某个软件包"这一知识本身变成**可版本化的数据**，与构建脚本一同由官方或第三方维护。
+2. 让 `ruyi` 作为编排入口自动执行该数据所描述的构建流程，并完成产物登记（校验和、大小、清单片段）以便后续合并进 `packages-index`。
+3. 不改变 `packages-index` 的既有 schema，不影响终端用户。
+
+## 核心概念
+
+### 构建配方仓库（build-recipe repository）
+
+一个**构建配方仓库**是一个独立的目录树（通常也是一个独立的 git 仓库），其根目录存在一个 `ruyi-build-recipes.toml` 标记文件。仓库内的 `*.star` 文件即**构建配方**，每一个配方描述了一个或多个可调度的构建任务。
+
+借鉴 `packages-index` 的 overlay 架构（详见[多软件源支持设计文档](./multi-repo-design.md)），用户可以同时配置多个构建配方仓库：
+
+* **官方配方仓库**：目前的 `ruyici` 仓库加上一份 `ruyi-build-recipes.toml` 即成为官方配方仓库；仓库内现有的 `ruyi-build-*` 外层脚本不再被 `ruyi` 直接调用，但可以继续用于手动调试。
+* **厂商/OEM 配方仓库**：硬件厂商可在自己的仓库中维护为特定开发板或 BSP 定制的构建流程。
+* **个人/实验配方仓库**：开发者可在本地仓库中临时编写配方，无需改动任何上游仓库。
+
+需要强调的是：配方仓库对**仓库内部布局**不做硬性约束。配方可以是 `recipes/foo.star`、`my-builds/bar.star` 乃至根目录下的 `baz.star`，均由配方作者自行决定。`ruyi` 只依赖标记文件定位项目根；配方之间的相互引用使用下文定义的 URI Scheme。
+
+### 构建配方（build recipe）
+
+一个构建配方是一份 Starlark 源文件，在顶层以与现有插件完全一致的方式声明 API 版本：
+
+```python
+RUYI = ruyi_plugin_rev(1)
+```
+
+配方在模块加载时通过 `RUYI.build.schedule_build(fn, name=...)` **显式注册**一个或多个可调度的构建函数。每个构建函数接收一个 `ctx` 参数，返回一个子进程调用计划（`Invocation`）。
+
+仅当宿主以"构建配方上下文"加载该 Starlark 模块时，`RUYI.build` 命名空间才可访问；普通插件尝试访问会得到明确的错误。该门控由新增的 `build-recipe-v1` feature flag 控制，复用现有 `RuyiHostAPI.has_feature()` 机制。
+
+### 配方项目根与安全边界
+
+`ruyi-build-recipes.toml` 不仅是一个分类标记，同时定义了一个安全边界：
+
+* `ruyi admin build-package ./xxx.star` 的行为是：对 `xxx.star` 取 `realpath`，自底向上查找第一个含有 `ruyi-build-recipes.toml` 的祖先目录，即视为**项目根**。若追溯到 `/` 仍未找到标记文件，则命令拒绝执行并给出清晰的错误信息。
+* 配方在使用 `ruyi-build://` URI 引用项目内其他文件时，最终解析路径必须仍落在项目根以内（反 `..` 逃逸检查）。
+* 构建产物默认落在项目根下的 `output_dir`（由标记文件声明，默认 `out/`）；若配方希望使用项目根之外的目录作为产物根，则该目录必须出现在标记文件的 `extra_artifact_roots` 白名单中。
+
+该约束与 Bazel 的 `WORKSPACE` / `MODULE.bazel` 根文件机制类似：将**项目边界**从"用户记得切换到哪里"这种易出错的隐式行为，转化为一条可被机器校验的显式事实。
+
+## 标记文件格式
+
+```toml
+format = "v1"
+
+[project]
+name = "ruyici"                     # 人类可读名称；用于日志与构建报告
+output_dir = "out"                  # 默认产物目录（相对项目根）
+extra_artifact_roots = ["/tmp"]     # 可选：允许产物落在项目根之外的绝对路径前缀白名单
+```
+
+未来新增字段（例如默认的 builder image 摘要、默认 subprocess 环境变量）时，沿用 `format = "vN"` 语义化递增；`ruyi` 核心对未知版本拒绝加载并建议升级 `ruyi`。
+
+## Starlark 宿主 API
+
+### 模块加载时（`RUYI`）
+
+* `RUYI = ruyi_plugin_rev(1)` — 与既有插件完全相同，仅在启用 `build-recipe-v1` feature 的宿主上下文中，`RUYI.build` 子命名空间才可访问。
+* `RUYI.build.schedule_build(fn, name=None)` — 注册一个构建函数。`name` 缺省时取 `fn.__name__`；同一配方内重名为错误；完整加载后未注册任何构建为错误。
+* `RUYI.log`、`RUYI.i18n`（若宿主上下文启用 i18n）— 沿用现有 `RuyiHostAPI` 中的对应字段，供配方输出进度或本地化提示。
+* 注意：`RUYI.call_subprocess_argv` 在构建配方上下文中被显式关闭。所有子进程调用必须经由下文的 `ctx.subprocess(...)` 以计划形式声明。
+
+### 构建执行时（`ctx`）
+
+`ctx` 是每次调度时由宿主新建的上下文对象，绑定到具体的某次被调度构建，仅在该 `fn(ctx)` 调用期间有效：
+
+* `ctx.subprocess(argv, cwd=None, env=None, produces=[]) -> Invocation` — 构造一个子进程调用计划。该方法**不立即执行**，仅返回一个不可变记录，由宿主在计划返回后统一调度。
+* `ctx.artifact(glob, root=None) -> Artifact` — 声明一个产物 glob。`root` 为 `None` 时取项目标记文件的 `output_dir`；为绝对路径时必须落在 `extra_artifact_roots` 允许的前缀下。
+* `ctx.var(name, default=None) -> str` — 读取命令行传入的 `-v NAME=VALUE` 变量。未提供且无默认值为错误。
+* `ctx.repo_root: str` — 项目根绝对路径。
+* `ctx.repo_path(rel: str) -> str` — 相对项目根的安全路径拼接（内含反 `..` 逃逸检查）。
+* `ctx.name: str` — 当前调度构建的名称；`ctx.recipe_file: str` — 触发本次调度的 `.star` 文件路径。两者主要用于错误信息与构建报告。
+
+故意保持极简：**核心 API 中不存在 `docker_run`、`driver`、`input_config` 这些概念**。Docker 封装与 image tag 管理属于"配方上用户空间"的工具，由配方作者在项目内以 Starlark 库的形式（例如 `lib/docker.star`）提供，通过 `ruyi-build://` URI 被其他配方 `load` 复用。`ruyi` 核心只认 `subprocess`。
+
+## 加载路径 URI Scheme
+
+现有的 `ruyi/pluginhost/paths.py` 已经支持以下 URI scheme：
+
+* `ruyi-plugin://<id>` — 按插件 ID 定位 `packages-index/plugins/<id>/mod.star`；
+* `ruyi-plugin-data://<id>/...` — 对应的数据文件访问。
+
+本设计在此基础上新增两个 scheme，语义一致但解析根不同：
+
+* `ruyi-build://<project-relative-path>` — 将路径解析为**当前配方项目根**下的子路径，用于加载项目内的 Starlark 代码；
+* `ruyi-build-data://<project-relative-path>` — 同上，但走数据加载通道（`is_for_data=True`），供 `load_toml` 等场景使用。
+
+两种 scheme 在解析后均强制执行反 `..` 逃逸检查，最终路径必须仍在项目根以内。裸 `//foo` 形式（不含 scheme）继续保持拒绝，与现有策略一致。
+
+在配方文件中的使用示例：
+
+```python
+RUYI = ruyi_plugin_rev(1)
+load("ruyi-build://lib/docker.star", "docker_run")
+load("ruyi-build://lib/images.star", "pkgbuilder_image_tag")
+```
+
+## 完整示例
+
+下例展示将现有 `ruyici/ruyi-build-qemu` 的一次 `both` 变体调用改写为配方：
+
+```python
+# recipes/qemu-riscv-upstream.star
+RUYI = ruyi_plugin_rev(1)
+
+load("ruyi-build://lib/docker.star", "docker_run")
+load("ruyi-build://lib/images.star", "pkgbuilder_image_tag")
+
+
+def build_qemu_riscv_upstream(ctx):
+    arch = ctx.var("arch", default = "amd64")
+    flavor = ctx.var("flavor", default = "both")
+
+    produces = []
+    if flavor in ("both", "system"):
+        produces.append(ctx.artifact(
+            glob = "qemu-system-riscv-upstream-*.%s.tar.zst" % arch))
+    if flavor in ("both", "user"):
+        produces.append(ctx.artifact(
+            glob = "qemu-user-riscv-upstream-*.%s.tar.zst" % arch))
+
+    return ctx.subprocess(
+        argv = docker_run(
+            image = pkgbuilder_image_tag("unified", "amd64"),
+            mounts_rw = [
+                (ctx.repo_path("out"), "/out"),
+                (ctx.repo_path("work"), "/work"),
+            ],
+            mounts_ro = [
+                (ctx.repo_path("ruyi-build-qemu-inner"),
+                 "/usr/local/bin/ruyi-build-qemu-inner"),
+                (ctx.repo_path("qemu-configs/upstream-20250908.sh"),
+                 "/tmp/config.sh"),
+                (ctx.repo_path("qemu-10.0.4.tar.xz"), "/tmp/src.tar.xz"),
+            ],
+            tmpfs = ["/tmp/mem"],
+            argv = ["ruyi-build-qemu-inner", "/tmp/config.sh", arch, flavor],
+        ),
+        cwd = ctx.repo_root,
+        produces = produces,
+    )
+
+
+RUYI.build.schedule_build(build_qemu_riscv_upstream)
+```
+
+对于需要"多主机矩阵"的场景（例如 `toolchain/gnu-upstream` 分别为 amd64/arm64/riscv64 三个主机产出 sysroot 归档），在配方顶层以 Python/Starlark 循环显式注册多次即可：
+
+```python
+for host in ("amd64", "arm64", "riscv64"):
+    RUYI.build.schedule_build(_make_plan(host), name = host)
+```
+
+Starlark 本身提供的 `if/for/字符串格式化`等能力足以覆盖所有分支/矩阵场景，无需在配方格式之外再引入 TOML schema 或占位符插值语言。
+
+## 命令行接口
+
+```
+ruyi admin build-package <RECIPE.star>
+    [-v, --var KEY=VALUE]...
+    [-n, --name BUILD_NAME]...
+    [--dry-run]
+    [--output-dir DIR]
+```
+
+* `<RECIPE.star>` — 指向要执行的配方文件的文件系统路径（绝对或相对）。
+* `-v / --var` — 以 `KEY=VALUE` 形式注入到 `ctx.var(...)` 可读取的变量空间；可重复。
+* `-n / --name` — 仅执行指定名称的调度构建；可重复；缺省时执行配方内全部注册构建。
+* `--dry-run` — 执行加载与计划构建阶段，但跳过 `subprocess` 实际执行；打印渲染后的 argv、env、cwd 以供审核。
+* `--output-dir` — 覆盖项目标记文件中声明的默认 `output_dir`。
+
+退出码：成功为 `0`；子进程失败原样透传其退出码；校验错误（标记文件不存在、配方未注册任何构建、`ctx.var` 无默认值且未传入等）为 `2`。
+
+## 构建报告
+
+对每一个成功执行的调度构建，宿主在产物目录下写入一个机器可读的构建报告：
+
+```
+<output_dir>/_ruyi-build-report.<recipe_slug>.<build_name>.<timestamp>.toml
+```
+
+内容包括：配方文件路径、构建名称、解析后的 argv/env/cwd、所有匹配到的产物绝对路径、每个产物的大小与 sha256/sha512，以及执行时间戳。该报告同时是未来可能实现的 `ruyi admin publish-package` 命令的消费对象。
+
+为便于操作者将构建结果补入 `packages-index`，命令在成功结束时向标准输出打印一段可直接粘贴的 `[[distfiles]]` TOML 片段。当前版本不自动修改任何 `packages-index` 清单。
+
+## 安全模型
+
+* **信任模型与现有插件一致**：配置或直接调用一个配方仓库，等同于以当前用户身份运行该仓库内任意代码。`ruyi` 不对配方内 `ctx.subprocess(...)` 的 argv 做允许列表校验；信任来源是"用户主动指向了该 `.star` 文件所属项目"。
+* **项目边界**由标记文件**客观决定**，不依赖环境变量、工作目录或 git 状态，从而避免"误把某个随意目录当作项目根"的隐性风险。
+* **路径逃逸**：`ruyi-build://`、`ruyi-build-data://`、`ctx.repo_path(...)` 均在 realpath 解析后强制路径仍位于项目根下；`ctx.artifact(root=...)` 的绝对路径必须落在 `extra_artifact_roots` 白名单中。
+* **模块加载上下文隔离**：`build-recipe-v1` feature 仅在以构建配方身份加载时启用；普通 `packages-index` 插件无法访问 `RUYI.build`；构建配方无法调用 `RUYI.call_subprocess_argv` 绕过 `ctx.subprocess` 的计划化管控。
+
+## 与现状的关系、演进路径
+
+* **`packages-index` 零改动**：不新增软件包 kind，不新增 category，不影响 `ruyi list` / `ruyi install` 等终端用户命令。
+* **`ruyici` 成为官方配方仓库**：仅需增加一份 `ruyi-build-recipes.toml`、`lib/docker.star`、`lib/images.star`，以及若干初始配方文件。现有 `ruyi-build-*` 外层脚本可保留用于手动调试，但不再作为 `ruyi admin build-package` 的入口。官方仓库可分阶段逐步将各 driver 从外层 bash 脚本迁移至 Starlark helper 库。
+* **`ruyi` 核心只新增装配代码与一个 admin 子命令**：不新增 package manager 概念，不修改既有 schema。
+
+后续工作（不在本设计范围内）：
+
+1. `ruyi admin publish-package`：串联构建、校验、上传、更新 `packages-index` 清单、提交 PR，将当前"构建报告→人工粘贴"的最后一步也自动化。
+2. 构建镜像摘要固定与重现性校验：将 builder image 的 `@sha256:...` 摘要写入标记文件或配方，执行时校验漂移。此能力可在"配方空间"或"核心"任一侧实现。
+3. 并行调度与缓存策略：在单次 `build-package` 调用内并行执行多个调度构建，或基于内容寻址跳过已完成的构建。

--- a/ruyi/pluginhost/api.py
+++ b/ruyi/pluginhost/api.py
@@ -14,6 +14,7 @@ from ..version import RUYI_SEMVER
 from .paths import resolve_ruyi_load_path
 
 if TYPE_CHECKING:
+    from .build_api import RuyiBuildRecipeAPI
     from .ctx import PluginHostContext, PluginLoadMode
     from .traits import SupportsEvalFunction, SupportsGetOption
 
@@ -109,6 +110,19 @@ class RuyiHostAPI:
     @cached_property
     def i18n(self) -> "RuyiPluginI18nAPI":
         return RuyiPluginI18nAPI(self._phctx)
+
+    #########################################################################
+
+    # Exported methods for the `build-recipe-v1` feature
+    @cached_property
+    def build(self) -> "RuyiBuildRecipeAPI":
+        if "build-recipe-v1" not in self._phctx.capabilities:
+            raise RuntimeError(
+                "RUYI.build is only available when loading a build recipe"
+            )
+        from .build_api import RuyiBuildRecipeAPI
+
+        return RuyiBuildRecipeAPI(self._phctx, self._this_file)
 
 
 class RuyiPluginI18nAPI:

--- a/ruyi/pluginhost/api.py
+++ b/ruyi/pluginhost/api.py
@@ -14,7 +14,7 @@ from ..version import RUYI_SEMVER
 from .paths import resolve_ruyi_load_path
 
 if TYPE_CHECKING:
-    from .ctx import PluginHostContext
+    from .ctx import PluginHostContext, PluginLoadMode
     from .traits import SupportsEvalFunction, SupportsGetOption
 
 T = TypeVar("T")
@@ -227,10 +227,9 @@ def make_ruyi_plugin_api_for_module(
     phctx: "PluginHostContext[SupportsGetOption, SupportsEvalFunction]",
     this_file: pathlib.Path,
     this_plugin_dir: pathlib.Path,
-    is_cmd: bool,
+    load_mode: "PluginLoadMode",
 ) -> Callable[[object], RuyiHostAPI]:
-    # Only allow access to host FS when we're being loaded as a command plugin
-    allow_host_fs_access = is_cmd
+    allow_host_fs_access = load_mode.allow_host_fs_access
 
     return lambda rev: _ruyi_plugin_rev(
         phctx,

--- a/ruyi/pluginhost/api.py
+++ b/ruyi/pluginhost/api.py
@@ -4,7 +4,7 @@ import pathlib
 import subprocess
 import time
 import tomllib
-from typing import TYPE_CHECKING, Any, Callable, Final, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from rich.console import Console, RenderableType
 
@@ -19,11 +19,6 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 U = TypeVar("U")
-
-
-FIXED_FEATURES: Final = {
-    "i18n-v1",
-}
 
 
 class RuyiHostAPI:
@@ -102,12 +97,7 @@ class RuyiHostAPI:
             return cast(U, self._ev.eval_function(fn, obj))
 
     def has_feature(self, feature: str) -> bool:
-        # Expose the i18n-v1 feature only if the host context is properly
-        # configured for it
-        match feature:
-            case "i18n-v1":
-                return self._phctx.has_i18n_capability()
-        return False
+        return feature in self._phctx.capabilities
 
     #########################################################################
 

--- a/ruyi/pluginhost/api.py
+++ b/ruyi/pluginhost/api.py
@@ -82,7 +82,10 @@ class RuyiHostAPI:
         self,
         argv: list[str],
     ) -> int:
-        # TODO: restrictions on this
+        if "call-subprocess-v1" not in self._phctx.capabilities:
+            raise RuntimeError(
+                "call_subprocess_argv is not available in this plugin context"
+            )
         return subprocess.call(argv)
 
     def sleep(self, seconds: float, /) -> None:

--- a/ruyi/pluginhost/api.py
+++ b/ruyi/pluginhost/api.py
@@ -54,6 +54,7 @@ class RuyiHostAPI:
             True,
             self._this_file,
             self._allow_host_fs_access,
+            recipe_project_root=self._phctx.recipe_project_root,
         )
         with open(resolved_path, "rb") as f:
             return tomllib.load(f)

--- a/ruyi/pluginhost/build_api.py
+++ b/ruyi/pluginhost/build_api.py
@@ -1,0 +1,77 @@
+"""Build-recipe-only additions to the RuyiHostAPI.
+
+Only reachable from inside a phctx where ``recipe_project_root`` is set
+(which in turn causes the ``build-recipe-v1`` capability to be granted
+and ``call-subprocess-v1`` to be revoked).
+
+At load time the recipe module gets a ``RUYI.build`` namespace exposing
+:meth:`RuyiBuildRecipeAPI.schedule_build`; later phases (B6+) will add
+the per-invocation ``ctx`` object and an executor.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, NamedTuple
+import pathlib
+
+if TYPE_CHECKING:
+    from .ctx import PluginHostContext
+    from .traits import SupportsEvalFunction, SupportsGetOption
+
+
+class ScheduledBuild(NamedTuple):
+    """A single build registered by a recipe at load time."""
+
+    name: str
+    fn: object
+    recipe_file: pathlib.Path
+
+
+class RuyiBuildRecipeAPI:
+    """The ``RUYI.build`` namespace for build-recipe modules."""
+
+    def __init__(
+        self,
+        phctx: "PluginHostContext[SupportsGetOption, SupportsEvalFunction]",
+        recipe_file: pathlib.Path,
+    ) -> None:
+        self._phctx = phctx
+        self._recipe_file = recipe_file
+
+    def schedule_build(
+        self,
+        fn: object,
+        name: str | None = None,
+    ) -> None:
+        """Register a scheduled build callable.
+
+        Must be called at module top level. ``name`` defaults to the
+        callable's ``__name__``; duplicate names within the same recipe
+        file raise :class:`RuntimeError`.
+        """
+
+        if not callable(fn):
+            raise RuntimeError(
+                f"schedule_build: expected a callable, got {type(fn).__name__}"
+            )
+
+        resolved_name = name if name is not None else getattr(fn, "__name__", None)
+        if not isinstance(resolved_name, str) or not resolved_name:
+            raise RuntimeError(
+                "schedule_build: could not derive a name from the callable; "
+                "pass name=... explicitly"
+            )
+
+        registry = self._phctx.scheduled_builds_for(self._recipe_file)
+        if any(sb.name == resolved_name for sb in registry):
+            raise RuntimeError(
+                f"schedule_build: duplicate build name {resolved_name!r} "
+                f"in recipe {self._recipe_file}"
+            )
+        registry.append(
+            ScheduledBuild(
+                name=resolved_name,
+                fn=fn,
+                recipe_file=self._recipe_file,
+            )
+        )

--- a/ruyi/pluginhost/build_api.py
+++ b/ruyi/pluginhost/build_api.py
@@ -197,7 +197,11 @@ class RecipeBuildCtx:
             root_path = pathlib.Path(root)
             if root_path.is_absolute():
                 resolved_root = root_path.resolve()
-                if resolved_root not in self._project.extra_artifact_roots and (
+                allowed_by_extras = any(
+                    resolved_root == extra or resolved_root.is_relative_to(extra)
+                    for extra in self._project.extra_artifact_roots
+                )
+                if not allowed_by_extras and (
                     not resolved_root.is_relative_to(self._project.root.resolve())
                 ):
                     raise RuntimeError(

--- a/ruyi/pluginhost/build_api.py
+++ b/ruyi/pluginhost/build_api.py
@@ -167,9 +167,7 @@ class RecipeBuildCtx:
         if not all(isinstance(x, str) for x in argv):
             raise RuntimeError("ctx.subprocess: argv entries must be strings")
 
-        resolved_cwd = (
-            self._project.root if cwd is None else pathlib.Path(cwd)
-        )
+        resolved_cwd = self._project.root if cwd is None else pathlib.Path(cwd)
         env_map = dict(env) if env is not None else {}
         produces_tuple = tuple(produces)
         for a in produces_tuple:

--- a/ruyi/pluginhost/build_api.py
+++ b/ruyi/pluginhost/build_api.py
@@ -5,14 +5,18 @@ Only reachable from inside a phctx where ``recipe_project_root`` is set
 and ``call-subprocess-v1`` to be revoked).
 
 At load time the recipe module gets a ``RUYI.build`` namespace exposing
-:meth:`RuyiBuildRecipeAPI.schedule_build`; later phases (B6+) will add
-the per-invocation ``ctx`` object and an executor.
+:meth:`RuyiBuildRecipeAPI.schedule_build`. At build time, each scheduled
+callable is invoked with a :class:`RecipeBuildCtx` that returns plans
+(:class:`Invocation`, :class:`Artifact`) rather than executing anything.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, NamedTuple
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Mapping, NamedTuple
 import pathlib
+
+from ..ruyipkg.recipe_project import RecipeProject, safe_join
 
 if TYPE_CHECKING:
     from .ctx import PluginHostContext
@@ -27,8 +31,31 @@ class ScheduledBuild(NamedTuple):
     recipe_file: pathlib.Path
 
 
+@dataclass(frozen=True)
+class Invocation:
+    """A declarative plan for a single subprocess invocation.
+
+    Produced by ``ctx.subprocess(...)``. The executor (B7) is responsible
+    for actually running it and, after a zero-exit, resolving the
+    :class:`Artifact` globs in :attr:`produces`.
+    """
+
+    argv: tuple[str, ...]
+    cwd: pathlib.Path
+    env: Mapping[str, str] = field(default_factory=dict)
+    produces: tuple["Artifact", ...] = ()
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """A declared build output matched against a glob under ``root``."""
+
+    glob: str
+    root: pathlib.Path
+
+
 class RuyiBuildRecipeAPI:
-    """The ``RUYI.build`` namespace for build-recipe modules."""
+    """The ``RUYI.build`` namespace for build-recipe modules (load time)."""
 
     def __init__(
         self,
@@ -75,3 +102,111 @@ class RuyiBuildRecipeAPI:
                 recipe_file=self._recipe_file,
             )
         )
+
+
+_MISSING = object()
+
+
+class RecipeBuildCtx:
+    """The per-build ``ctx`` object passed to each scheduled callable.
+
+    All methods return *plans* — they do not execute subprocesses or
+    touch the filesystem beyond path resolution and traversal checks.
+    """
+
+    def __init__(
+        self,
+        project: RecipeProject,
+        name: str,
+        recipe_file: pathlib.Path,
+        user_vars: Mapping[str, str],
+    ) -> None:
+        self._project = project
+        self._name = name
+        self._recipe_file = recipe_file
+        self._user_vars = dict(user_vars)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def recipe_file(self) -> str:
+        return str(self._recipe_file)
+
+    @property
+    def repo_root(self) -> str:
+        return str(self._project.root)
+
+    def repo_path(self, rel: str) -> str:
+        return str(safe_join(self._project.root, rel))
+
+    def var(self, name: str, default: object = _MISSING) -> str:
+        if name in self._user_vars:
+            return self._user_vars[name]
+        if default is _MISSING:
+            raise RuntimeError(
+                f"ctx.var: no value provided for {name!r} and no default given"
+            )
+        if not isinstance(default, str):
+            raise RuntimeError(
+                f"ctx.var: default for {name!r} must be a string "
+                f"(got {type(default).__name__})"
+            )
+        return default
+
+    def subprocess(
+        self,
+        argv: list[str] | tuple[str, ...],
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        produces: list["Artifact"] | tuple["Artifact", ...] = (),
+    ) -> Invocation:
+        if not argv:
+            raise RuntimeError("ctx.subprocess: argv must be non-empty")
+        if not all(isinstance(x, str) for x in argv):
+            raise RuntimeError("ctx.subprocess: argv entries must be strings")
+
+        resolved_cwd = (
+            self._project.root if cwd is None else pathlib.Path(cwd)
+        )
+        env_map = dict(env) if env is not None else {}
+        produces_tuple = tuple(produces)
+        for a in produces_tuple:
+            if not isinstance(a, Artifact):
+                raise RuntimeError(
+                    "ctx.subprocess: produces entries must be Artifact values "
+                    "(returned by ctx.artifact(...))"
+                )
+        return Invocation(
+            argv=tuple(argv),
+            cwd=resolved_cwd,
+            env=env_map,
+            produces=produces_tuple,
+        )
+
+    def artifact(
+        self,
+        glob: str,
+        root: str | None = None,
+    ) -> Artifact:
+        if not glob:
+            raise RuntimeError("ctx.artifact: glob must be a non-empty string")
+
+        if root is None:
+            resolved_root = self._project.output_dir
+        else:
+            root_path = pathlib.Path(root)
+            if root_path.is_absolute():
+                resolved_root = root_path.resolve()
+                if resolved_root not in self._project.extra_artifact_roots and (
+                    not resolved_root.is_relative_to(self._project.root.resolve())
+                ):
+                    raise RuntimeError(
+                        f"ctx.artifact: absolute root {resolved_root} is not in "
+                        f"extra_artifact_roots and not inside the project"
+                    )
+            else:
+                resolved_root = safe_join(self._project.root, root)
+
+        return Artifact(glob=glob, root=resolved_root)

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -1,4 +1,5 @@
 import abc
+import enum
 from functools import cached_property
 import os
 import pathlib
@@ -21,6 +22,33 @@ from .traits import SupportsEvalFunction, SupportsGetOption, SupportsMessageStor
 
 
 ENV_PLUGIN_BACKEND_KEY: Final = "RUYI_PLUGIN_BACKEND"
+
+
+class PluginLoadMode(enum.Enum):
+    """The context in which a Starlark module is being loaded.
+
+    The mode controls which host API surfaces are exposed to the loaded
+    module and what file system accesses are permitted.
+
+    * ``PACKAGE_PLUGIN``: an ordinary plugin shipped inside a packages-index
+      repository (profile plugins, device-provisioner strategies, ...).
+      These have no access to the host filesystem outside of their plugin
+      directory.
+    * ``COMMAND_PLUGIN``: a ``ruyi-cmd-*`` plugin implementing a user-facing
+      ``ruyi`` subcommand. Allowed to reach into the host filesystem via
+      the ``host://`` load path scheme.
+    * ``BUILD_RECIPE``: a ``ruyi admin build-package`` recipe. Rooted at a
+      ``ruyi-build-recipes.toml`` project root; may register scheduled
+      builds but has no host-FS access through load paths.
+    """
+
+    PACKAGE_PLUGIN = "package-plugin"
+    COMMAND_PLUGIN = "command-plugin"
+    BUILD_RECIPE = "build-recipe"
+
+    @property
+    def allow_host_fs_access(self) -> bool:
+        return self is PluginLoadMode.COMMAND_PLUGIN
 
 
 ModuleTy = TypeVar("ModuleTy", bound=SupportsGetOption, covariant=True)
@@ -76,7 +104,7 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
         self,
         originating_file: pathlib.Path,
         module_cache: MutableMapping[str, ModuleTy],
-        is_cmd: bool,
+        load_mode: PluginLoadMode,
     ) -> "BasePluginLoader[ModuleTy]":
         raise NotImplementedError
 
@@ -92,13 +120,13 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
     def plugin_root(self) -> pathlib.Path:
         return self._plugin_root
 
-    def load_plugin(self, plugin_id: str, is_cmd: bool) -> None:
+    def load_plugin(self, plugin_id: str, load_mode: PluginLoadMode) -> None:
         plugin_dir = paths.get_plugin_dir(plugin_id, self._plugin_root)
 
         loader = self.make_loader(
             plugin_dir / paths.PLUGIN_ENTRYPOINT_FILENAME,
             self._module_cache,
-            is_cmd,
+            load_mode,
         )
         loaded_plugin = loader.load_this_plugin()
         self._loaded_plugins[plugin_id] = loaded_plugin
@@ -113,7 +141,12 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
         is_cmd_plugin: bool = False,
     ) -> object | None:
         if not self.is_plugin_loaded(plugin_id):
-            self.load_plugin(plugin_id, is_cmd_plugin)
+            load_mode = (
+                PluginLoadMode.COMMAND_PLUGIN
+                if is_cmd_plugin
+                else PluginLoadMode.PACKAGE_PLUGIN
+            )
+            self.load_plugin(plugin_id, load_mode)
 
         if plugin_id not in self._value_cache:
             self._value_cache[plugin_id] = {}
@@ -157,12 +190,12 @@ class BasePluginLoader(Generic[ModuleTy], metaclass=abc.ABCMeta):
         phctx: PluginHostContext[ModuleTy, SupportsEvalFunction],
         originating_file: pathlib.Path,
         module_cache: MutableMapping[str, ModuleTy],
-        is_cmd: bool,
+        load_mode: PluginLoadMode,
     ) -> None:
         self._phctx = phctx
         self.originating_file = originating_file
         self.module_cache = module_cache
-        self.is_cmd = is_cmd
+        self.load_mode = load_mode
 
     @property
     def host_logger(self) -> RuyiLogger:
@@ -177,7 +210,7 @@ class BasePluginLoader(Generic[ModuleTy], metaclass=abc.ABCMeta):
             self._phctx,
             originating_file,
             self.module_cache,
-            self.is_cmd,
+            self.load_mode,
         )
 
     def load_this_plugin(self) -> ModuleTy:
@@ -196,7 +229,7 @@ class BasePluginLoader(Generic[ModuleTy], metaclass=abc.ABCMeta):
                 self.root,
                 False,
                 self.originating_file,
-                self.is_cmd,
+                self.load_mode.allow_host_fs_access,
             )
         resolved_path_str = str(resolved_path)
         if resolved_path_str in self.module_cache:
@@ -209,7 +242,7 @@ class BasePluginLoader(Generic[ModuleTy], metaclass=abc.ABCMeta):
             self._phctx,
             resolved_path,
             plugin_dir,
-            self.is_cmd,
+            self.load_mode,
         )
 
         mod = self.do_load_module(

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -157,6 +157,23 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
     def all_scheduled_builds(self) -> dict[pathlib.Path, list[ScheduledBuild]]:
         return self._scheduled_builds
 
+    def load_recipe(self, recipe_file: pathlib.Path) -> list[ScheduledBuild]:
+        """Load a build-recipe ``.star`` file via a fresh loader using the
+        host context's shared module cache, then return the list of
+        :class:`ScheduledBuild` entries registered during the load.
+
+        Intended for callers outside the pluginhost package so they can
+        drive recipe loading without reaching into private state.
+        """
+
+        loader = self.make_loader(
+            recipe_file,
+            self._module_cache,
+            PluginLoadMode.BUILD_RECIPE,
+        )
+        loader.load_this_plugin()
+        return list(self.scheduled_builds_for(recipe_file))
+
     def load_plugin(self, plugin_id: str, load_mode: PluginLoadMode) -> None:
         plugin_dir = paths.get_plugin_dir(plugin_id, self._plugin_root)
 

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -99,7 +99,7 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
         self._locale = locale or ""
         self._msg_store_factory = message_store_factory
 
-        capabilities: set[str] = set()
+        capabilities: set[str] = {"call-subprocess-v1"}
         if self.has_i18n_capability():
             # Expose the i18n-v1 feature only if the host context is properly
             # configured for it

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -277,8 +277,17 @@ class BasePluginLoader(Generic[ModuleTy], metaclass=abc.ABCMeta):
         if resolved_path_str in self.module_cache:
             return self.module_cache[resolved_path_str]
 
-        plugin_id = resolved_path.relative_to(self.root).parts[0]
-        plugin_dir = self.root / plugin_id
+        if self.load_mode is PluginLoadMode.BUILD_RECIPE:
+            recipe_root = self._phctx.recipe_project_root
+            if recipe_root is None:
+                raise RuntimeError(
+                    "BUILD_RECIPE load mode requires a recipe_project_root on "
+                    "the host context"
+                )
+            plugin_dir = recipe_root
+        else:
+            plugin_id = resolved_path.relative_to(self.root).parts[0]
+            plugin_dir = self.root / plugin_id
 
         host_bridge = api.make_ruyi_plugin_api_for_module(
             self._phctx,

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -63,6 +63,7 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
         *,
         locale: str | None = None,
         message_store_factory: Callable[[], SupportsMessageStore] | None = None,
+        recipe_project_root: pathlib.Path | None = None,
     ) -> "PluginHostContext[SupportsGetOption, SupportsEvalFunction]":
         plugin_backend = os.environ.get("RUYI_PLUGIN_BACKEND", "")
         if not plugin_backend:
@@ -75,6 +76,7 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
                     plugin_root,
                     locale=locale,
                     message_store_factory=message_store_factory,
+                    recipe_project_root=recipe_project_root,
                 )
             case _:
                 raise RuntimeError(f"unsupported plugin backend: {plugin_backend}")
@@ -86,6 +88,7 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
         *,
         locale: str | None = None,
         message_store_factory: Callable[[], SupportsMessageStore] | None = None,
+        recipe_project_root: pathlib.Path | None = None,
     ) -> None:
         self._host_logger = host_logger
         self._plugin_root = plugin_root
@@ -98,6 +101,7 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
 
         self._locale = locale or ""
         self._msg_store_factory = message_store_factory
+        self._recipe_project_root = recipe_project_root
 
         capabilities: set[str] = {"call-subprocess-v1"}
         if self.has_i18n_capability():
@@ -126,6 +130,10 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
     @property
     def plugin_root(self) -> pathlib.Path:
         return self._plugin_root
+
+    @property
+    def recipe_project_root(self) -> pathlib.Path | None:
+        return self._recipe_project_root
 
     def load_plugin(self, plugin_id: str, load_mode: PluginLoadMode) -> None:
         plugin_dir = paths.get_plugin_dir(plugin_id, self._plugin_root)
@@ -241,6 +249,7 @@ class BasePluginLoader(Generic[ModuleTy], metaclass=abc.ABCMeta):
                 False,
                 self.originating_file,
                 self.load_mode.allow_host_fs_access,
+                recipe_project_root=self._phctx.recipe_project_root,
             )
         resolved_path_str = str(resolved_path)
         if resolved_path_str in self.module_cache:

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -99,6 +99,13 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
         self._locale = locale or ""
         self._msg_store_factory = message_store_factory
 
+        capabilities: set[str] = set()
+        if self.has_i18n_capability():
+            # Expose the i18n-v1 feature only if the host context is properly
+            # configured for it
+            capabilities.add("i18n-v1")
+        self._capabilities: frozenset[str] = frozenset(capabilities)
+
     @abc.abstractmethod
     def make_loader(
         self,
@@ -160,6 +167,10 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
 
     def has_i18n_capability(self) -> bool:
         return self._msg_store_factory is not None
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        return self._capabilities
 
     @property
     def locale(self) -> str:

--- a/ruyi/pluginhost/ctx.py
+++ b/ruyi/pluginhost/ctx.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 from ..log import RuyiLogger
 from . import api
 from . import paths
+from .build_api import ScheduledBuild
 from .traits import SupportsEvalFunction, SupportsGetOption, SupportsMessageStore
 
 
@@ -108,7 +109,14 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
             # Expose the i18n-v1 feature only if the host context is properly
             # configured for it
             capabilities.add("i18n-v1")
+        if recipe_project_root is not None:
+            capabilities.add("build-recipe-v1")
+            capabilities.discard("call-subprocess-v1")
         self._capabilities: frozenset[str] = frozenset(capabilities)
+
+        # Scheduled builds, populated by RUYI.build.schedule_build during
+        # load of a build-recipe module. Keyed by recipe file path.
+        self._scheduled_builds: dict[pathlib.Path, list["ScheduledBuild"]] = {}
 
     @abc.abstractmethod
     def make_loader(
@@ -134,6 +142,20 @@ class PluginHostContext(Generic[ModuleTy, EvalTy], metaclass=abc.ABCMeta):
     @property
     def recipe_project_root(self) -> pathlib.Path | None:
         return self._recipe_project_root
+
+    def scheduled_builds_for(
+        self,
+        recipe_file: pathlib.Path,
+    ) -> list[ScheduledBuild]:
+        """Return (creating if needed) the scheduled-build registry for
+        the given recipe file. Shared by all ``RUYI.build.schedule_build``
+        calls within the same module load.
+        """
+
+        return self._scheduled_builds.setdefault(recipe_file, [])
+
+    def all_scheduled_builds(self) -> dict[pathlib.Path, list[ScheduledBuild]]:
+        return self._scheduled_builds
 
     def load_plugin(self, plugin_id: str, load_mode: PluginLoadMode) -> None:
         plugin_dir = paths.get_plugin_dir(plugin_id, self._plugin_root)

--- a/ruyi/pluginhost/paths.py
+++ b/ruyi/pluginhost/paths.py
@@ -1,7 +1,7 @@
 import pathlib
 import re
 from typing import Final
-from urllib.parse import unquote, urlparse
+from urllib.parse import ParseResult, unquote, urlparse
 
 PLUGIN_ENTRYPOINT_FILENAME: Final = "mod.star"
 PLUGIN_DATA_DIR: Final = "data"
@@ -24,6 +24,7 @@ def resolve_ruyi_load_path(
     is_for_data: bool,
     originating_file: pathlib.Path,
     allow_host_fs_access: bool,
+    recipe_project_root: pathlib.Path | None = None,
 ) -> pathlib.Path:
     parsed = urlparse(path)
     if parsed.params or parsed.query or parsed.fragment:
@@ -98,10 +99,57 @@ def resolve_ruyi_load_path(
 
             return pathlib.Path(parsed.path)
 
+        case "ruyi-build":
+            if is_for_data:
+                raise RuntimeError(
+                    "the ruyi-build protocol is not allowed in this context"
+                )
+            return _resolve_ruyi_build(parsed, recipe_project_root)
+
+        case "ruyi-build-data":
+            if not is_for_data:
+                raise RuntimeError(
+                    "the ruyi-build-data protocol is not allowed in this context"
+                )
+            return _resolve_ruyi_build(parsed, recipe_project_root)
+
         case _:
             raise RuntimeError(
                 f"unsupported Ruyi Starlark load path scheme {parsed.scheme}"
             )
+
+
+def _resolve_ruyi_build(
+    parsed: ParseResult,
+    recipe_project_root: pathlib.Path | None,
+) -> pathlib.Path:
+    if recipe_project_root is None:
+        raise RuntimeError(
+            f"the {parsed.scheme} protocol is only available when loading "
+            f"a build recipe"
+        )
+    if not parsed.netloc and not parsed.path:
+        raise RuntimeError(
+            f"empty path is not allowed for {parsed.scheme}:// load paths"
+        )
+
+    # Reconstruct the repo-relative path. urlparse of "ruyi-build://lib/x.star"
+    # puts "lib" in netloc and "/x.star" in path; reassemble them.
+    combined = parsed.netloc + parsed.path
+    rel = combined.lstrip("/")
+    if not rel:
+        raise RuntimeError(
+            f"empty path is not allowed for {parsed.scheme}:// load paths"
+        )
+
+    root_resolved = recipe_project_root.resolve()
+    joined = (root_resolved / pathlib.PurePosixPath(rel)).resolve()
+    if not joined.is_relative_to(root_resolved):
+        raise RuntimeError(
+            f"{parsed.scheme}:// load path {combined!r} escapes "
+            f"recipe project root {root_resolved}"
+        )
+    return joined
 
 
 def resolve_plain_load_path(

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from typing_extensions import Buffer
 
 from .api import RuyiHostAPI
-from .ctx import PluginHostContext, BasePluginLoader
+from .ctx import PluginHostContext, BasePluginLoader, PluginLoadMode
 
 
 class UnsandboxedModuleDict(dict[str, object]):
@@ -74,9 +74,11 @@ class UnsandboxedPluginHostContext(
         self,
         originating_file: pathlib.Path,
         module_cache: MutableMapping[str, UnsandboxedModuleDict],
-        is_cmd: bool,
+        load_mode: PluginLoadMode,
     ) -> BasePluginLoader[UnsandboxedModuleDict]:
-        return UnsandboxedRuyiPluginLoader(self, originating_file, module_cache, is_cmd)
+        return UnsandboxedRuyiPluginLoader(
+            self, originating_file, module_cache, load_mode
+        )
 
     def make_evaluator(self) -> UnsandboxedTrivialEvaluator:
         return UnsandboxedTrivialEvaluator()

--- a/ruyi/ruyipkg/admin_cli.py
+++ b/ruyi/ruyipkg/admin_cli.py
@@ -84,3 +84,107 @@ class AdminFormatManifestCommand(
                 fp.write(d)
 
         return 0
+
+
+class AdminBuildPackageCommand(
+    AdminCommand,
+    cmd="build-package",
+    help=_("Build a package from a recipe file"),
+):
+    @classmethod
+    def configure_args(cls, gc: "GlobalConfig", p: "ArgumentParser") -> None:
+        p.add_argument(
+            "recipe_file",
+            type=str,
+            help=_("Path to the recipe .star file"),
+        )
+        p.add_argument(
+            "-v",
+            "--var",
+            action="append",
+            default=[],
+            metavar="KEY=VALUE",
+            help=_("Set a user variable for the recipe (repeatable)"),
+        )
+        p.add_argument(
+            "-n",
+            "--name",
+            action="append",
+            default=[],
+            metavar="NAME",
+            help=_(
+                "Select a specific scheduled build by name (repeatable); "
+                "by default all scheduled builds are executed"
+            ),
+        )
+        p.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_("Print the build plan without executing it"),
+        )
+        p.add_argument(
+            "--output-dir",
+            type=str,
+            default=None,
+            help=_("Override the recipe project's output directory"),
+        )
+
+    @classmethod
+    def main(cls, cfg: "GlobalConfig", args: argparse.Namespace) -> int:
+        from .build_runner import (
+            BuildFailure,
+            format_build_report,
+            run_recipe,
+        )
+
+        logger = cfg.logger
+        recipe_file = pathlib.Path(cast(str, args.recipe_file))
+        var_strs = cast("list[str]", args.var)
+        selected_names = cast("list[str]", args.name) or None
+        dry_run = cast(bool, args.dry_run)
+        output_dir_raw = cast("str | None", args.output_dir)
+        output_dir = (
+            pathlib.Path(output_dir_raw) if output_dir_raw is not None else None
+        )
+
+        user_vars: dict[str, str] = {}
+        for v in var_strs:
+            if "=" not in v:
+                logger.F(
+                    _("invalid --var spec {spec!r}: expected KEY=VALUE").format(
+                        spec=v,
+                    )
+                )
+                return 1
+            k, _sep, val = v.partition("=")
+            if not k:
+                logger.F(_("invalid --var spec {spec!r}: empty key").format(spec=v))
+                return 1
+            user_vars[k] = val
+
+        try:
+            reports = run_recipe(
+                logger,
+                recipe_file,
+                user_vars=user_vars,
+                selected_names=selected_names,
+                dry_run=dry_run,
+                output_dir_override=output_dir,
+            )
+        except BuildFailure as e:
+            logger.F(str(e))
+            return e.exit_code or 1
+        except (RuntimeError, FileNotFoundError) as e:
+            logger.F(str(e))
+            return 1
+
+        for r in reports:
+            logger.I(
+                _("build {name!r} completed: {n} artifact(s)").format(
+                    name=r.build_name, n=len(r.artifacts),
+                )
+            )
+            print(format_build_report(r))
+
+        return 0
+

--- a/ruyi/ruyipkg/admin_cli.py
+++ b/ruyi/ruyipkg/admin_cli.py
@@ -181,10 +181,10 @@ class AdminBuildPackageCommand(
         for r in reports:
             logger.I(
                 _("build {name!r} completed: {n} artifact(s)").format(
-                    name=r.build_name, n=len(r.artifacts),
+                    name=r.build_name,
+                    n=len(r.artifacts),
                 )
             )
             print(format_build_report(r))
 
         return 0
-

--- a/ruyi/ruyipkg/build_runner.py
+++ b/ruyi/ruyipkg/build_runner.py
@@ -41,8 +41,7 @@ if TYPE_CHECKING:
 class ArtifactReport:
     path: pathlib.Path
     size: int
-    sha256: str
-    sha512: str
+    checksums: Mapping[str, str]
 
 
 @dataclass(frozen=True)
@@ -141,16 +140,8 @@ def _make_recipe_phctx(
 def _load_recipe_module(
     phctx: "PluginHostContext[Any, Any]", recipe_file: pathlib.Path
 ) -> list[ScheduledBuild]:
-    from ..pluginhost.ctx import PluginLoadMode
-
     resolved = recipe_file.resolve(strict=True)
-    loader = phctx.make_loader(
-        resolved,
-        phctx._module_cache,
-        PluginLoadMode.BUILD_RECIPE,
-    )
-    loader.load_this_plugin()
-    return list(phctx.scheduled_builds_for(resolved))
+    return phctx.load_recipe(resolved)
 
 
 def _filter_by_name(
@@ -260,7 +251,9 @@ def _run_invocation(logger: RuyiLogger, inv: Invocation) -> int:
 def _resolve_artifacts(
     invocations: Iterable[Invocation],
 ) -> list[ArtifactReport]:
-    import hashlib
+    import os
+
+    from . import checksum
 
     reports: list[ArtifactReport] = []
     for inv in invocations:
@@ -273,13 +266,16 @@ def _resolve_artifacts(
             for match in matches:
                 if not match.is_file():
                     continue
-                data = match.read_bytes()
+                with open(match, "rb") as fp:
+                    size = os.stat(fp.fileno()).st_size
+                    csums = checksum.Checksummer(fp, {}).compute(
+                        kinds=checksum.SUPPORTED_CHECKSUM_KINDS,
+                    )
                 reports.append(
                     ArtifactReport(
                         path=match,
-                        size=len(data),
-                        sha256=hashlib.sha256(data).hexdigest(),
-                        sha512=hashlib.sha512(data).hexdigest(),
+                        size=size,
+                        checksums=csums,
                     )
                 )
     return reports
@@ -306,6 +302,6 @@ def format_build_report(report: BuildReport) -> str:
         lines.append("[[artifacts]]")
         lines.append(f'path = "{art.path}"')
         lines.append(f"size = {art.size}")
-        lines.append(f'sha256 = "{art.sha256}"')
-        lines.append(f'sha512 = "{art.sha512}"')
+        for kind in sorted(art.checksums):
+            lines.append(f'{kind} = "{art.checksums[kind]}"')
     return "\n".join(lines) + "\n"

--- a/ruyi/ruyipkg/build_runner.py
+++ b/ruyi/ruyipkg/build_runner.py
@@ -240,7 +240,7 @@ def _run_invocation(logger: RuyiLogger, inv: Invocation) -> int:
     # project, and the invocation takes an argv list with no shell expansion,
     # which is the documented threat model.
     proc = subprocess.run(
-        list(inv.argv),
+        list(inv.argv),  # sourcery skip: dangerous-subprocess-use-audit
         cwd=str(inv.cwd),
         env=merged_env,
         check=False,

--- a/ruyi/ruyipkg/build_runner.py
+++ b/ruyi/ruyipkg/build_runner.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import pathlib
-from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 from ..log import RuyiLogger
 from ..pluginhost.build_api import (
@@ -127,7 +127,7 @@ def _with_output_dir(
 
 def _make_recipe_phctx(
     logger: RuyiLogger, project: RecipeProject
-) -> "PluginHostContext":
+) -> "PluginHostContext[Any, Any]":
     # Local import: keeps heavy module-load chains out of CLI startup.
     from ..pluginhost.ctx import PluginHostContext
 
@@ -139,14 +139,14 @@ def _make_recipe_phctx(
 
 
 def _load_recipe_module(
-    phctx: "PluginHostContext", recipe_file: pathlib.Path
+    phctx: "PluginHostContext[Any, Any]", recipe_file: pathlib.Path
 ) -> list[ScheduledBuild]:
     from ..pluginhost.ctx import PluginLoadMode
 
     resolved = recipe_file.resolve(strict=True)
     loader = phctx.make_loader(
         resolved,
-        phctx._module_cache,  # type: ignore[attr-defined]
+        phctx._module_cache,
         PluginLoadMode.BUILD_RECIPE,
     )
     loader.load_this_plugin()
@@ -167,7 +167,7 @@ def _filter_by_name(
 
 def _execute_one_build(
     logger: RuyiLogger,
-    phctx: "PluginHostContext",
+    phctx: "PluginHostContext[Any, Any]",
     project: RecipeProject,
     sb: ScheduledBuild,
     *,

--- a/ruyi/ruyipkg/build_runner.py
+++ b/ruyi/ruyipkg/build_runner.py
@@ -59,9 +59,7 @@ class BuildFailure(RuntimeError):
     """Raised when an Invocation exits non-zero."""
 
     def __init__(self, build_name: str, exit_code: int) -> None:
-        super().__init__(
-            f"build {build_name!r} failed with exit code {exit_code}"
-        )
+        super().__init__(f"build {build_name!r} failed with exit code {exit_code}")
         self.build_name = build_name
         self.exit_code = exit_code
 
@@ -216,9 +214,7 @@ def _execute_one_build(
     )
 
 
-def _normalize_invocations(
-    build_name: str, result: object
-) -> list[Invocation]:
+def _normalize_invocations(build_name: str, result: object) -> list[Invocation]:
     if isinstance(result, Invocation):
         return [result]
     if isinstance(result, (list, tuple)):

--- a/ruyi/ruyipkg/build_runner.py
+++ b/ruyi/ruyipkg/build_runner.py
@@ -1,0 +1,315 @@
+"""Executor for ``ruyi admin build-package``.
+
+Given a path to a recipe ``.star`` file, this module:
+
+1. Discovers the enclosing recipe project (via :mod:`recipe_project`).
+2. Builds a :class:`PluginHostContext` in build-recipe mode.
+3. Loads the recipe module, collecting :class:`ScheduledBuild`
+   registrations.
+4. For each (optionally ``--name``-filtered) scheduled build, constructs
+   a :class:`RecipeBuildCtx` and calls the registered callable to obtain
+   one or more :class:`Invocation` plans.
+5. Executes each plan via :func:`subprocess.run` unless ``dry_run`` is
+   set; on a zero exit, resolves declared ``produces`` globs, computes
+   sha256/sha512/size for each matched file, and writes a build-report
+   TOML.
+
+The runner is intentionally I/O-heavy at call time and light on imports
+at the module top level so that the CLI startup-flow lint stays happy;
+all subprocess/hashlib/tomllib usage is inside :func:`run_recipe`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pathlib
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
+
+from ..log import RuyiLogger
+from ..pluginhost.build_api import (
+    Invocation,
+    RecipeBuildCtx,
+    ScheduledBuild,
+)
+from .recipe_project import RecipeProject, discover_recipe_project
+
+if TYPE_CHECKING:
+    from ..pluginhost.ctx import PluginHostContext
+
+
+@dataclass(frozen=True)
+class ArtifactReport:
+    path: pathlib.Path
+    size: int
+    sha256: str
+    sha512: str
+
+
+@dataclass(frozen=True)
+class BuildReport:
+    recipe_file: pathlib.Path
+    project_name: str
+    build_name: str
+    invocations: tuple[Invocation, ...]
+    artifacts: tuple[ArtifactReport, ...]
+    exit_code: int
+
+
+class BuildFailure(RuntimeError):
+    """Raised when an Invocation exits non-zero."""
+
+    def __init__(self, build_name: str, exit_code: int) -> None:
+        super().__init__(
+            f"build {build_name!r} failed with exit code {exit_code}"
+        )
+        self.build_name = build_name
+        self.exit_code = exit_code
+
+
+def run_recipe(
+    logger: RuyiLogger,
+    recipe_file: pathlib.Path,
+    *,
+    user_vars: Mapping[str, str] | None = None,
+    selected_names: Sequence[str] | None = None,
+    dry_run: bool = False,
+    output_dir_override: pathlib.Path | None = None,
+) -> list[BuildReport]:
+    """Load the recipe and execute (or plan, if ``dry_run``) each selected
+    scheduled build.
+
+    Returns a :class:`BuildReport` per executed build. Raises
+    :class:`BuildFailure` on the first non-zero exit (subsequent builds
+    are not attempted).
+    """
+
+    project = discover_recipe_project(recipe_file)
+    if output_dir_override is not None:
+        project = _with_output_dir(project, output_dir_override)
+
+    phctx = _make_recipe_phctx(logger, project)
+    scheduled = _load_recipe_module(phctx, recipe_file)
+    if not scheduled:
+        raise RuntimeError(
+            f"recipe {recipe_file} scheduled no builds "
+            f"(did you call RUYI.build.schedule_build(...)?)"
+        )
+
+    if selected_names is not None:
+        selected = _filter_by_name(scheduled, selected_names)
+    else:
+        selected = list(scheduled)
+
+    reports: list[BuildReport] = []
+    for sb in selected:
+        reports.append(
+            _execute_one_build(
+                logger,
+                phctx,
+                project,
+                sb,
+                user_vars=user_vars or {},
+                dry_run=dry_run,
+            )
+        )
+    return reports
+
+
+def _with_output_dir(
+    project: RecipeProject, new_output_dir: pathlib.Path
+) -> RecipeProject:
+    resolved = new_output_dir.resolve()
+    return RecipeProject(
+        root=project.root,
+        name=project.name,
+        output_dir=resolved,
+        extra_artifact_roots=project.extra_artifact_roots,
+    )
+
+
+def _make_recipe_phctx(
+    logger: RuyiLogger, project: RecipeProject
+) -> "PluginHostContext":
+    # Local import: keeps heavy module-load chains out of CLI startup.
+    from ..pluginhost.ctx import PluginHostContext
+
+    return PluginHostContext.new(
+        logger,
+        project.root,  # plugin_root is reused for the recipe project
+        recipe_project_root=project.root,
+    )
+
+
+def _load_recipe_module(
+    phctx: "PluginHostContext", recipe_file: pathlib.Path
+) -> list[ScheduledBuild]:
+    from ..pluginhost.ctx import PluginLoadMode
+
+    resolved = recipe_file.resolve(strict=True)
+    loader = phctx.make_loader(
+        resolved,
+        phctx._module_cache,  # type: ignore[attr-defined]
+        PluginLoadMode.BUILD_RECIPE,
+    )
+    loader.load_this_plugin()
+    return list(phctx.scheduled_builds_for(resolved))
+
+
+def _filter_by_name(
+    scheduled: Iterable[ScheduledBuild], wanted: Sequence[str]
+) -> list[ScheduledBuild]:
+    by_name = {sb.name: sb for sb in scheduled}
+    missing = [n for n in wanted if n not in by_name]
+    if missing:
+        raise RuntimeError(
+            f"recipe does not define the requested build(s): {', '.join(missing)}"
+        )
+    return [by_name[n] for n in wanted]
+
+
+def _execute_one_build(
+    logger: RuyiLogger,
+    phctx: "PluginHostContext",
+    project: RecipeProject,
+    sb: ScheduledBuild,
+    *,
+    user_vars: Mapping[str, str],
+    dry_run: bool,
+) -> BuildReport:
+    ctx = RecipeBuildCtx(
+        project=project,
+        name=sb.name,
+        recipe_file=sb.recipe_file,
+        user_vars=user_vars,
+    )
+    ev = phctx.make_evaluator()
+    result = ev.eval_function(sb.fn, ctx)
+    invocations = _normalize_invocations(sb.name, result)
+
+    if dry_run:
+        for inv in invocations:
+            logger.I(f"[dry-run] would run: {' '.join(inv.argv)} (cwd={inv.cwd})")
+        return BuildReport(
+            recipe_file=sb.recipe_file,
+            project_name=project.name,
+            build_name=sb.name,
+            invocations=tuple(invocations),
+            artifacts=(),
+            exit_code=0,
+        )
+
+    last_exit = 0
+    for inv in invocations:
+        last_exit = _run_invocation(logger, inv)
+        if last_exit != 0:
+            raise BuildFailure(sb.name, last_exit)
+
+    artifact_reports = _resolve_artifacts(invocations)
+
+    return BuildReport(
+        recipe_file=sb.recipe_file,
+        project_name=project.name,
+        build_name=sb.name,
+        invocations=tuple(invocations),
+        artifacts=tuple(artifact_reports),
+        exit_code=last_exit,
+    )
+
+
+def _normalize_invocations(
+    build_name: str, result: object
+) -> list[Invocation]:
+    if isinstance(result, Invocation):
+        return [result]
+    if isinstance(result, (list, tuple)):
+        out: list[Invocation] = []
+        for item in result:
+            if not isinstance(item, Invocation):
+                raise RuntimeError(
+                    f"build {build_name!r}: expected Invocation (from "
+                    f"ctx.subprocess), got {type(item).__name__}"
+                )
+            out.append(item)
+        if not out:
+            raise RuntimeError(
+                f"build {build_name!r}: returned an empty list of Invocations"
+            )
+        return out
+    raise RuntimeError(
+        f"build {build_name!r}: expected Invocation or list of Invocations, "
+        f"got {type(result).__name__}"
+    )
+
+
+def _run_invocation(logger: RuyiLogger, inv: Invocation) -> int:
+    import os
+    import subprocess
+
+    logger.I(f"running: {' '.join(inv.argv)} (cwd={inv.cwd})")
+    merged_env = os.environ.copy()
+    merged_env.update(inv.env)
+
+    # SECURITY: recipes are explicit Starlark code evaluated in a trusted recipe
+    # project, and the invocation takes an argv list with no shell expansion,
+    # which is the documented threat model.
+    proc = subprocess.run(
+        list(inv.argv),
+        cwd=str(inv.cwd),
+        env=merged_env,
+        check=False,
+    )
+    return proc.returncode
+
+
+def _resolve_artifacts(
+    invocations: Iterable[Invocation],
+) -> list[ArtifactReport]:
+    import hashlib
+
+    reports: list[ArtifactReport] = []
+    for inv in invocations:
+        for art in inv.produces:
+            matches = sorted(art.root.glob(art.glob))
+            if not matches:
+                raise RuntimeError(
+                    f"artifact {art.glob!r} under {art.root} matched no files"
+                )
+            for match in matches:
+                if not match.is_file():
+                    continue
+                data = match.read_bytes()
+                reports.append(
+                    ArtifactReport(
+                        path=match,
+                        size=len(data),
+                        sha256=hashlib.sha256(data).hexdigest(),
+                        sha512=hashlib.sha512(data).hexdigest(),
+                    )
+                )
+    return reports
+
+
+def format_build_report(report: BuildReport) -> str:
+    """Return a TOML-shaped serialization of a build report."""
+
+    lines: list[str] = []
+    lines.append("# ruyi build report")
+    lines.append(f'recipe_file = "{report.recipe_file}"')
+    lines.append(f'project_name = "{report.project_name}"')
+    lines.append(f'build_name = "{report.build_name}"')
+    lines.append(f"exit_code = {report.exit_code}")
+    for inv in report.invocations:
+        lines.append("")
+        lines.append("[[invocations]]")
+        lines.append(f"argv = {list(inv.argv)!r}")
+        lines.append(f'cwd = "{inv.cwd}"')
+        if inv.env:
+            lines.append(f"env = {dict(inv.env)!r}")
+    for art in report.artifacts:
+        lines.append("")
+        lines.append("[[artifacts]]")
+        lines.append(f'path = "{art.path}"')
+        lines.append(f"size = {art.size}")
+        lines.append(f'sha256 = "{art.sha256}"')
+        lines.append(f'sha512 = "{art.sha512}"')
+    return "\n".join(lines) + "\n"

--- a/ruyi/ruyipkg/recipe_project.py
+++ b/ruyi/ruyipkg/recipe_project.py
@@ -1,0 +1,164 @@
+"""Recipe-project discovery and marker-file parsing.
+
+A *recipe project* is a directory tree with a ``ruyi-build-recipes.toml``
+marker at its root. Build recipes (``.star`` files) anywhere beneath the
+root may ``load()`` each other via the ``ruyi-build://`` scheme.
+
+This module owns the on-disk representation: discovery of the project
+root given a recipe file, parsing the marker, and a realpath-based join
+helper used by loaders and the build runner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import pathlib
+import tomllib
+from typing import Any
+
+
+MARKER_FILENAME = "ruyi-build-recipes.toml"
+SUPPORTED_FORMATS = frozenset({"v1"})
+
+
+class RecipeProjectError(RuntimeError):
+    """Raised for any ruyi-build-recipes.toml or project-layout problem."""
+
+
+@dataclass(frozen=True)
+class RecipeProject:
+    """A discovered recipe project.
+
+    Attributes:
+        root: Absolute, realpath-resolved path to the project root.
+        name: Human-readable project name from the marker, or the root
+            directory name if unspecified.
+        output_dir: Project-relative directory for build outputs; absolute
+            path computed as ``root / output_dir``.
+        extra_artifact_roots: Absolute allow-list for artifact roots
+            outside the project tree. Each entry is realpath-resolved.
+    """
+
+    root: pathlib.Path
+    name: str
+    output_dir: pathlib.Path
+    extra_artifact_roots: tuple[pathlib.Path, ...] = field(default_factory=tuple)
+
+    @property
+    def marker_path(self) -> pathlib.Path:
+        return self.root / MARKER_FILENAME
+
+
+def discover_recipe_project(recipe_file: pathlib.Path) -> RecipeProject:
+    """Find the recipe project containing ``recipe_file``.
+
+    Walks the lexical parents of ``recipe_file`` looking for the marker
+    file. The realpath of the recipe file must remain within the realpath
+    of the project root (defense against symlink escape). Raises
+    :class:`RecipeProjectError` if no marker is found or if the realpath
+    check fails.
+    """
+
+    if not recipe_file.exists():
+        raise RecipeProjectError(f"recipe file not found: {recipe_file}")
+
+    recipe_abs = recipe_file.absolute()
+    resolved_recipe = recipe_file.resolve(strict=True)
+
+    for candidate in (recipe_abs.parent, *recipe_abs.parents):
+        marker = candidate / MARKER_FILENAME
+        if marker.is_file():
+            root = candidate.resolve(strict=True)
+            if not resolved_recipe.is_relative_to(root):
+                raise RecipeProjectError(
+                    f"recipe file {recipe_file} escapes its project root {root} "
+                    f"after realpath resolution"
+                )
+            return _parse_marker(root, marker)
+
+    raise RecipeProjectError(
+        f"no {MARKER_FILENAME} found in any parent of {recipe_file}"
+    )
+
+
+def _parse_marker(root: pathlib.Path, marker: pathlib.Path) -> RecipeProject:
+    try:
+        with open(marker, "rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise RecipeProjectError(f"malformed {MARKER_FILENAME} at {marker}: {e}") from e
+
+    fmt = data.get("format")
+    if fmt not in SUPPORTED_FORMATS:
+        raise RecipeProjectError(
+            f"{marker}: unsupported or missing 'format' (got {fmt!r}; "
+            f"expected one of {sorted(SUPPORTED_FORMATS)})"
+        )
+
+    project_section: Any = data.get("project", {})
+    if not isinstance(project_section, dict):
+        raise RecipeProjectError(f"{marker}: [project] must be a table")
+
+    name = project_section.get("name", root.name)
+    if not isinstance(name, str) or not name:
+        raise RecipeProjectError(f"{marker}: project.name must be a non-empty string")
+
+    output_dir_raw = project_section.get("output_dir", "out")
+    if not isinstance(output_dir_raw, str) or not output_dir_raw:
+        raise RecipeProjectError(
+            f"{marker}: project.output_dir must be a non-empty string"
+        )
+    output_dir_rel = pathlib.PurePosixPath(output_dir_raw)
+    if output_dir_rel.is_absolute():
+        raise RecipeProjectError(
+            f"{marker}: project.output_dir must be a project-relative path"
+        )
+    output_dir = (root / output_dir_rel).resolve()
+    if not output_dir.is_relative_to(root):
+        raise RecipeProjectError(
+            f"{marker}: project.output_dir escapes the project root"
+        )
+
+    extra_raw = project_section.get("extra_artifact_roots", [])
+    if not isinstance(extra_raw, list) or not all(isinstance(x, str) for x in extra_raw):
+        raise RecipeProjectError(
+            f"{marker}: project.extra_artifact_roots must be a list of strings"
+        )
+    extras: list[pathlib.Path] = []
+    for entry in extra_raw:
+        p = pathlib.Path(entry)
+        if not p.is_absolute():
+            raise RecipeProjectError(
+                f"{marker}: extra_artifact_roots entries must be absolute paths "
+                f"(got {entry!r})"
+            )
+        extras.append(p.resolve())
+
+    return RecipeProject(
+        root=root,
+        name=name,
+        output_dir=output_dir,
+        extra_artifact_roots=tuple(extras),
+    )
+
+
+def safe_join(root: pathlib.Path, rel: str) -> pathlib.Path:
+    """Join ``rel`` onto ``root`` and verify the result stays inside ``root``.
+
+    Used when resolving ``ruyi-build://``-scheme paths and ``ctx.repo_path``
+    calls. Accepts either forward-slash relative paths or plain relative
+    paths; absolute inputs are rejected.
+    """
+
+    p = pathlib.PurePosixPath(rel)
+    if p.is_absolute():
+        raise RecipeProjectError(
+            f"safe_join: absolute paths are not allowed (got {rel!r})"
+        )
+    joined = (root / p).resolve()
+    root_resolved = root.resolve()
+    if not joined.is_relative_to(root_resolved):
+        raise RecipeProjectError(
+            f"safe_join: {rel!r} escapes recipe project root {root_resolved}"
+        )
+    return joined

--- a/ruyi/ruyipkg/recipe_project.py
+++ b/ruyi/ruyipkg/recipe_project.py
@@ -120,7 +120,9 @@ def _parse_marker(root: pathlib.Path, marker: pathlib.Path) -> RecipeProject:
         )
 
     extra_raw = project_section.get("extra_artifact_roots", [])
-    if not isinstance(extra_raw, list) or not all(isinstance(x, str) for x in extra_raw):
+    if not isinstance(extra_raw, list) or not all(
+        isinstance(x, str) for x in extra_raw
+    ):
         raise RecipeProjectError(
             f"{marker}: project.extra_artifact_roots must be a list of strings"
         )

--- a/tests/integration/test_admin_build_package.py
+++ b/tests/integration/test_admin_build_package.py
@@ -1,0 +1,113 @@
+"""CLI integration tests for `ruyi admin build-package` (B8)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from tests.fixtures import IntegrationTestHarness
+
+
+def _setup_project(tmp_path: pathlib.Path, recipe_body: str) -> pathlib.Path:
+    proj = tmp_path / "recipes-proj"
+    proj.mkdir()
+    (proj / "ruyi-build-recipes.toml").write_text(
+        'format = "v1"\n[project]\nname = "integ"\n'
+    )
+    (proj / "out").mkdir()
+    recipe = proj / "pkg.star"
+    recipe.write_text(recipe_body)
+    return recipe
+
+
+def test_admin_build_package_dry_run(
+    tmp_path: pathlib.Path,
+    ruyi_cli_runner: IntegrationTestHarness,
+) -> None:
+    recipe = _setup_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true'])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+
+    result = ruyi_cli_runner(
+        "admin", "build-package", "--dry-run", str(recipe)
+    )
+    assert result.exit_code == 0, result.stderr
+    assert "build_it" in result.stdout
+
+
+def test_admin_build_package_executes(
+    tmp_path: pathlib.Path,
+    ruyi_cli_runner: IntegrationTestHarness,
+) -> None:
+    recipe = _setup_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true'])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    result = ruyi_cli_runner("admin", "build-package", str(recipe))
+    assert result.exit_code == 0, result.stderr
+
+
+def test_admin_build_package_var_flag(
+    tmp_path: pathlib.Path,
+    ruyi_cli_runner: IntegrationTestHarness,
+) -> None:
+    recipe = _setup_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/echo', ctx.var('arch')])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    result = ruyi_cli_runner(
+        "admin",
+        "build-package",
+        "--dry-run",
+        "-v",
+        "arch=riscv64",
+        str(recipe),
+    )
+    assert result.exit_code == 0, result.stderr
+    assert "riscv64" in result.stdout
+
+
+def test_admin_build_package_invalid_var(
+    tmp_path: pathlib.Path,
+    ruyi_cli_runner: IntegrationTestHarness,
+) -> None:
+    recipe = _setup_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true'])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    result = ruyi_cli_runner(
+        "admin",
+        "build-package",
+        "--dry-run",
+        "-v",
+        "no_equals_here",
+        str(recipe),
+    )
+    assert result.exit_code == 1
+
+
+def test_admin_build_package_build_failure_exits_nonzero(
+    tmp_path: pathlib.Path,
+    ruyi_cli_runner: IntegrationTestHarness,
+) -> None:
+    recipe = _setup_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/false'])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    result = ruyi_cli_runner("admin", "build-package", str(recipe))
+    assert result.exit_code != 0

--- a/tests/integration/test_admin_build_package.py
+++ b/tests/integration/test_admin_build_package.py
@@ -31,9 +31,7 @@ def test_admin_build_package_dry_run(
         "RUYI.build.schedule_build(build_it)\n",
     )
 
-    result = ruyi_cli_runner(
-        "admin", "build-package", "--dry-run", str(recipe)
-    )
+    result = ruyi_cli_runner("admin", "build-package", "--dry-run", str(recipe))
     assert result.exit_code == 0, result.stderr
     assert "build_it" in result.stdout
 

--- a/tests/pluginhost/test_build_recipe_api.py
+++ b/tests/pluginhost/test_build_recipe_api.py
@@ -1,6 +1,7 @@
 """Tests for RuyiBuildRecipeAPI (B5)."""
 
 import pathlib
+from typing import Any
 
 import pytest
 
@@ -13,7 +14,7 @@ from ruyi.pluginhost.ctx import PluginHostContext
 def _make_recipe_phctx(
     tmp_path: pathlib.Path,
     ruyi_logger: RuyiLogger,
-) -> PluginHostContext:
+) -> PluginHostContext[Any, Any]:
     plugin_root = tmp_path / "plugins"
     plugin_root.mkdir()
     recipe_root = tmp_path / "recipes_proj"
@@ -28,7 +29,7 @@ def _make_recipe_phctx(
 def _make_plain_phctx(
     tmp_path: pathlib.Path,
     ruyi_logger: RuyiLogger,
-) -> PluginHostContext:
+) -> PluginHostContext[Any, Any]:
     plugin_root = tmp_path / "plugins"
     plugin_root.mkdir()
     return PluginHostContext.new(ruyi_logger, plugin_root)
@@ -77,7 +78,7 @@ def test_schedule_build_rejects_non_callable(
     api = RuyiBuildRecipeAPI(phctx, recipe_file)
 
     with pytest.raises(RuntimeError, match="expected a callable"):
-        api.schedule_build("not a function")  # type: ignore[arg-type]
+        api.schedule_build("not a function")
 
 
 def test_schedule_build_accepts_lambda(

--- a/tests/pluginhost/test_build_recipe_api.py
+++ b/tests/pluginhost/test_build_recipe_api.py
@@ -130,7 +130,9 @@ def test_build_namespace_gated_on_capability(
         this_plugin_dir=tmp_path,
         allow_host_fs_access=False,
     )
-    with pytest.raises(RuntimeError, match="only available when loading a build recipe"):
+    with pytest.raises(
+        RuntimeError, match="only available when loading a build recipe"
+    ):
         _ = host_api.build
 
 
@@ -162,4 +164,3 @@ def test_call_subprocess_rejected_in_recipe_context(
     )
     with pytest.raises(RuntimeError, match="call_subprocess_argv is not available"):
         host_api.call_subprocess_argv(["/bin/true"])
-

--- a/tests/pluginhost/test_build_recipe_api.py
+++ b/tests/pluginhost/test_build_recipe_api.py
@@ -1,0 +1,165 @@
+"""Tests for RuyiBuildRecipeAPI (B5)."""
+
+import pathlib
+
+import pytest
+
+from ruyi.log import RuyiLogger
+from ruyi.pluginhost.api import RuyiHostAPI
+from ruyi.pluginhost.build_api import RuyiBuildRecipeAPI, ScheduledBuild
+from ruyi.pluginhost.ctx import PluginHostContext
+
+
+def _make_recipe_phctx(
+    tmp_path: pathlib.Path,
+    ruyi_logger: RuyiLogger,
+) -> PluginHostContext:
+    plugin_root = tmp_path / "plugins"
+    plugin_root.mkdir()
+    recipe_root = tmp_path / "recipes_proj"
+    recipe_root.mkdir()
+    return PluginHostContext.new(
+        ruyi_logger,
+        plugin_root,
+        recipe_project_root=recipe_root,
+    )
+
+
+def _make_plain_phctx(
+    tmp_path: pathlib.Path,
+    ruyi_logger: RuyiLogger,
+) -> PluginHostContext:
+    plugin_root = tmp_path / "plugins"
+    plugin_root.mkdir()
+    return PluginHostContext.new(ruyi_logger, plugin_root)
+
+
+def test_schedule_build_registers_callable(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+
+    api = RuyiBuildRecipeAPI(phctx, recipe_file)
+
+    def build_one(ctx: object) -> None:
+        pass
+
+    api.schedule_build(build_one)
+
+    registry = phctx.scheduled_builds_for(recipe_file)
+    assert len(registry) == 1
+    sb = registry[0]
+    assert isinstance(sb, ScheduledBuild)
+    assert sb.name == "build_one"
+    assert sb.fn is build_one
+    assert sb.recipe_file == recipe_file
+
+
+def test_schedule_build_explicit_name(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    api = RuyiBuildRecipeAPI(phctx, recipe_file)
+
+    api.schedule_build(lambda ctx: None, name="custom")
+
+    registry = phctx.scheduled_builds_for(recipe_file)
+    assert [sb.name for sb in registry] == ["custom"]
+
+
+def test_schedule_build_rejects_non_callable(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    api = RuyiBuildRecipeAPI(phctx, recipe_file)
+
+    with pytest.raises(RuntimeError, match="expected a callable"):
+        api.schedule_build("not a function")  # type: ignore[arg-type]
+
+
+def test_schedule_build_accepts_lambda(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    api = RuyiBuildRecipeAPI(phctx, recipe_file)
+
+    api.schedule_build(lambda ctx: None)
+    assert phctx.scheduled_builds_for(recipe_file)[0].name == "<lambda>"
+
+
+def test_schedule_build_rejects_duplicate_name(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    api = RuyiBuildRecipeAPI(phctx, recipe_file)
+
+    api.schedule_build(lambda ctx: None, name="dup")
+    with pytest.raises(RuntimeError, match="duplicate build name"):
+        api.schedule_build(lambda ctx: None, name="dup")
+
+
+def test_recipe_phctx_has_build_recipe_capability(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    assert "build-recipe-v1" in phctx.capabilities
+    # Recipes must go through ctx.subprocess; raw subprocess is denied.
+    assert "call-subprocess-v1" not in phctx.capabilities
+
+
+def test_plain_phctx_does_not_have_build_recipe_capability(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_plain_phctx(tmp_path, ruyi_logger)
+    assert "build-recipe-v1" not in phctx.capabilities
+    assert "call-subprocess-v1" in phctx.capabilities
+
+
+def test_build_namespace_gated_on_capability(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_plain_phctx(tmp_path, ruyi_logger)
+    host_api = RuyiHostAPI(
+        phctx,
+        this_file=tmp_path / "unused.star",
+        this_plugin_dir=tmp_path,
+        allow_host_fs_access=False,
+    )
+    with pytest.raises(RuntimeError, match="only available when loading a build recipe"):
+        _ = host_api.build
+
+
+def test_build_namespace_available_in_recipe_context(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    host_api = RuyiHostAPI(
+        phctx,
+        this_file=recipe_file,
+        this_plugin_dir=tmp_path / "recipes_proj",
+        allow_host_fs_access=False,
+    )
+    build = host_api.build
+    assert isinstance(build, RuyiBuildRecipeAPI)
+
+
+def test_call_subprocess_rejected_in_recipe_context(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    host_api = RuyiHostAPI(
+        phctx,
+        this_file=recipe_file,
+        this_plugin_dir=tmp_path / "recipes_proj",
+        allow_host_fs_access=False,
+    )
+    with pytest.raises(RuntimeError, match="call_subprocess_argv is not available"):
+        host_api.call_subprocess_argv(["/bin/true"])
+

--- a/tests/pluginhost/test_build_recipe_api.py
+++ b/tests/pluginhost/test_build_recipe_api.py
@@ -92,6 +92,21 @@ def test_schedule_build_accepts_lambda(
     assert phctx.scheduled_builds_for(recipe_file)[0].name == "<lambda>"
 
 
+def test_schedule_build_rejects_callable_without_derivable_name(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    class CallableWithoutName:
+        def __call__(self, ctx: Any) -> None:
+            pass
+
+    phctx = _make_recipe_phctx(tmp_path, ruyi_logger)
+    recipe_file = tmp_path / "recipes_proj" / "pkg.star"
+    api = RuyiBuildRecipeAPI(phctx, recipe_file)
+
+    with pytest.raises(RuntimeError, match="could not derive a name"):
+        api.schedule_build(CallableWithoutName())
+
+
 def test_schedule_build_rejects_duplicate_name(
     tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
 ) -> None:

--- a/tests/pluginhost/test_paths.py
+++ b/tests/pluginhost/test_paths.py
@@ -1,0 +1,150 @@
+import pathlib
+
+import pytest
+
+from ruyi.pluginhost.paths import resolve_ruyi_load_path
+
+
+@pytest.fixture
+def plugin_root(tmp_path: pathlib.Path) -> pathlib.Path:
+    root = tmp_path / "plugins"
+    (root / "alpha").mkdir(parents=True)
+    (root / "alpha" / "mod.star").write_text("")
+    (root / "alpha" / "sub.star").write_text("")
+    (root / "alpha" / "data").mkdir()
+    (root / "alpha" / "data" / "foo.toml").write_text("")
+    (root / "beta").mkdir()
+    (root / "beta" / "mod.star").write_text("")
+    (root / "beta" / "data").mkdir()
+    (root / "beta" / "data" / "bar.toml").write_text("")
+    return root
+
+
+def test_plain_relative_within_plugin(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    resolved = resolve_ruyi_load_path(
+        "sub.star", plugin_root, False, originating, False
+    )
+    assert resolved == (plugin_root / "alpha" / "sub.star").resolve()
+
+
+def test_plain_absolute_resolves_against_plugin_root(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    resolved = resolve_ruyi_load_path(
+        "/sub.star", plugin_root, False, originating, False
+    )
+    assert resolved == plugin_root / "alpha" / "sub.star"
+
+
+def test_plain_cross_plugin_boundary_rejected(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(ValueError, match="cross plugin boundary"):
+        resolve_ruyi_load_path(
+            "../beta/mod.star", plugin_root, False, originating, False
+        )
+
+
+def test_ruyi_plugin_scheme_resolves_entrypoint(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    resolved = resolve_ruyi_load_path(
+        "ruyi-plugin://beta", plugin_root, False, originating, False
+    )
+    assert resolved == plugin_root / "beta" / "mod.star"
+
+
+def test_ruyi_plugin_scheme_rejects_data_context(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="ruyi-plugin protocol"):
+        resolve_ruyi_load_path(
+            "ruyi-plugin://beta", plugin_root, True, originating, False
+        )
+
+
+def test_ruyi_plugin_scheme_rejects_path_segment(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="non-empty path segment"):
+        resolve_ruyi_load_path(
+            "ruyi-plugin://beta/extra", plugin_root, False, originating, False
+        )
+
+
+def test_ruyi_plugin_scheme_rejects_empty_netloc(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="empty location"):
+        resolve_ruyi_load_path("ruyi-plugin://", plugin_root, False, originating, False)
+
+
+def test_ruyi_plugin_data_scheme_resolves_under_data(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    resolved = resolve_ruyi_load_path(
+        "ruyi-plugin-data://beta/bar.toml",
+        plugin_root,
+        True,
+        originating,
+        False,
+    )
+    assert resolved == plugin_root / "beta" / "data" / "bar.toml"
+
+
+def test_ruyi_plugin_data_scheme_rejects_non_data_context(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="ruyi-plugin-data protocol"):
+        resolve_ruyi_load_path(
+            "ruyi-plugin-data://beta/bar.toml",
+            plugin_root,
+            False,
+            originating,
+            False,
+        )
+
+
+def test_host_scheme_requires_allow_host_fs_access(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="host protocol"):
+        resolve_ruyi_load_path(
+            "host:///etc/hostname", plugin_root, False, originating, False
+        )
+
+
+def test_host_scheme_returns_absolute_path_when_allowed(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    resolved = resolve_ruyi_load_path(
+        "host:///etc/hostname", plugin_root, False, originating, True
+    )
+    assert resolved == pathlib.Path("/etc/hostname")
+
+
+def test_fancy_uri_features_rejected(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="fancy URI features"):
+        resolve_ruyi_load_path(
+            "ruyi-plugin://beta?x=1", plugin_root, False, originating, False
+        )
+
+
+def test_unknown_scheme_rejected(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="unsupported Ruyi Starlark load path"):
+        resolve_ruyi_load_path(
+            "gopher://whatever", plugin_root, False, originating, False
+        )
+
+
+def test_double_slash_prefix_rejected(plugin_root: pathlib.Path) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="'//' is not allowed"):
+        resolve_ruyi_load_path("//evil", plugin_root, False, originating, False)

--- a/tests/pluginhost/test_paths.py
+++ b/tests/pluginhost/test_paths.py
@@ -148,3 +148,121 @@ def test_double_slash_prefix_rejected(plugin_root: pathlib.Path) -> None:
     originating = plugin_root / "alpha" / "mod.star"
     with pytest.raises(RuntimeError, match="'//' is not allowed"):
         resolve_ruyi_load_path("//evil", plugin_root, False, originating, False)
+
+
+# --- ruyi-build:// / ruyi-build-data:// ---------------------------------
+
+
+@pytest.fixture
+def recipe_project(tmp_path: pathlib.Path) -> pathlib.Path:
+    root = tmp_path / "recipes_proj"
+    (root / "lib").mkdir(parents=True)
+    (root / "lib" / "docker.star").write_text("")
+    (root / "cfg.toml").write_text("")
+    (root / "recipes").mkdir()
+    (root / "recipes" / "pkg.star").write_text("")
+    return root
+
+
+def test_ruyi_build_resolves_against_project_root(
+    plugin_root: pathlib.Path, recipe_project: pathlib.Path
+) -> None:
+    originating = recipe_project / "recipes" / "pkg.star"
+    resolved = resolve_ruyi_load_path(
+        "ruyi-build://lib/docker.star",
+        plugin_root,
+        False,
+        originating,
+        False,
+        recipe_project_root=recipe_project,
+    )
+    assert resolved == (recipe_project / "lib" / "docker.star").resolve()
+
+
+def test_ruyi_build_rejected_outside_recipe_context(
+    plugin_root: pathlib.Path,
+) -> None:
+    originating = plugin_root / "alpha" / "mod.star"
+    with pytest.raises(RuntimeError, match="only available when loading"):
+        resolve_ruyi_load_path(
+            "ruyi-build://lib/docker.star",
+            plugin_root,
+            False,
+            originating,
+            False,
+        )
+
+
+def test_ruyi_build_rejects_traversal(
+    plugin_root: pathlib.Path, recipe_project: pathlib.Path
+) -> None:
+    originating = recipe_project / "recipes" / "pkg.star"
+    with pytest.raises(RuntimeError, match="escapes recipe project root"):
+        resolve_ruyi_load_path(
+            "ruyi-build://../../etc/passwd",
+            plugin_root,
+            False,
+            originating,
+            False,
+            recipe_project_root=recipe_project,
+        )
+
+
+def test_ruyi_build_rejects_data_context(
+    plugin_root: pathlib.Path, recipe_project: pathlib.Path
+) -> None:
+    originating = recipe_project / "recipes" / "pkg.star"
+    with pytest.raises(RuntimeError, match="ruyi-build protocol"):
+        resolve_ruyi_load_path(
+            "ruyi-build://cfg.toml",
+            plugin_root,
+            True,
+            originating,
+            False,
+            recipe_project_root=recipe_project,
+        )
+
+
+def test_ruyi_build_data_resolves(
+    plugin_root: pathlib.Path, recipe_project: pathlib.Path
+) -> None:
+    originating = recipe_project / "recipes" / "pkg.star"
+    resolved = resolve_ruyi_load_path(
+        "ruyi-build-data://cfg.toml",
+        plugin_root,
+        True,
+        originating,
+        False,
+        recipe_project_root=recipe_project,
+    )
+    assert resolved == (recipe_project / "cfg.toml").resolve()
+
+
+def test_ruyi_build_data_rejects_non_data_context(
+    plugin_root: pathlib.Path, recipe_project: pathlib.Path
+) -> None:
+    originating = recipe_project / "recipes" / "pkg.star"
+    with pytest.raises(RuntimeError, match="ruyi-build-data protocol"):
+        resolve_ruyi_load_path(
+            "ruyi-build-data://cfg.toml",
+            plugin_root,
+            False,
+            originating,
+            False,
+            recipe_project_root=recipe_project,
+        )
+
+
+def test_ruyi_build_rejects_empty_path(
+    plugin_root: pathlib.Path, recipe_project: pathlib.Path
+) -> None:
+    originating = recipe_project / "recipes" / "pkg.star"
+    with pytest.raises(RuntimeError, match="empty path"):
+        resolve_ruyi_load_path(
+            "ruyi-build://",
+            plugin_root,
+            False,
+            originating,
+            False,
+            recipe_project_root=recipe_project,
+        )

--- a/tests/pluginhost/test_recipe_build_ctx.py
+++ b/tests/pluginhost/test_recipe_build_ctx.py
@@ -1,0 +1,164 @@
+"""Tests for RecipeBuildCtx and plan records (B6)."""
+
+import pathlib
+
+import pytest
+
+from ruyi.pluginhost.build_api import (
+    Artifact,
+    Invocation,
+    RecipeBuildCtx,
+)
+from ruyi.ruyipkg.recipe_project import RecipeProject
+
+
+def _make_project(tmp_path: pathlib.Path) -> RecipeProject:
+    root = tmp_path.resolve()
+    (root / "out").mkdir(exist_ok=True)
+    return RecipeProject(
+        root=root,
+        name="test",
+        output_dir=(root / "out").resolve(),
+        extra_artifact_roots=((tmp_path / "scratch").resolve(),),
+    )
+
+
+def _make_ctx(
+    tmp_path: pathlib.Path,
+    user_vars: dict[str, str] | None = None,
+) -> RecipeBuildCtx:
+    (tmp_path / "scratch").mkdir(exist_ok=True)
+    project = _make_project(tmp_path)
+    recipe = project.root / "recipes" / "pkg.star"
+    recipe.parent.mkdir(parents=True, exist_ok=True)
+    recipe.write_text("")
+    return RecipeBuildCtx(
+        project=project,
+        name="b1",
+        recipe_file=recipe,
+        user_vars=user_vars or {},
+    )
+
+
+def test_ctx_identity_fields(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    assert ctx.name == "b1"
+    assert ctx.recipe_file.endswith("pkg.star")
+    assert ctx.repo_root == str(tmp_path.resolve())
+
+
+def test_ctx_repo_path_safe_join(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "src").mkdir()
+    assert ctx.repo_path("src") == str((tmp_path / "src").resolve())
+
+
+def test_ctx_repo_path_traversal_rejected(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="escapes recipe project root"):
+        ctx.repo_path("../evil")
+
+
+def test_ctx_var_returns_provided(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path, user_vars={"arch": "riscv64"})
+    assert ctx.var("arch") == "riscv64"
+
+
+def test_ctx_var_default(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    assert ctx.var("arch", default="amd64") == "amd64"
+
+
+def test_ctx_var_missing_no_default_errors(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="no value provided"):
+        ctx.var("arch")
+
+
+def test_ctx_var_non_string_default_rejected(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="must be a string"):
+        ctx.var("arch", default=42)  # type: ignore[arg-type]
+
+
+def test_ctx_subprocess_returns_plan(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    inv = ctx.subprocess(
+        argv=["/bin/true", "hello"],
+        env={"FOO": "bar"},
+    )
+    assert isinstance(inv, Invocation)
+    assert inv.argv == ("/bin/true", "hello")
+    assert inv.cwd == tmp_path.resolve()
+    assert inv.env == {"FOO": "bar"}
+    assert inv.produces == ()
+
+
+def test_ctx_subprocess_rejects_empty_argv(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="argv must be non-empty"):
+        ctx.subprocess(argv=[])
+
+
+def test_ctx_subprocess_rejects_non_string_argv(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="argv entries must be strings"):
+        ctx.subprocess(argv=["/bin/true", 1])  # type: ignore[list-item]
+
+
+def test_ctx_subprocess_rejects_non_artifact_produces(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="produces entries must be Artifact"):
+        ctx.subprocess(argv=["/bin/true"], produces=["foo.tar"])  # type: ignore[list-item]
+
+
+def test_ctx_subprocess_carries_produces(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    a = ctx.artifact("*.tar.zst")
+    inv = ctx.subprocess(argv=["/bin/true"], produces=[a])
+    assert inv.produces == (a,)
+
+
+def test_ctx_artifact_defaults_to_output_dir(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    a = ctx.artifact("*.tar.zst")
+    assert isinstance(a, Artifact)
+    assert a.glob == "*.tar.zst"
+    assert a.root == (tmp_path / "out").resolve()
+
+
+def test_ctx_artifact_relative_root_resolved_under_project(
+    tmp_path: pathlib.Path,
+) -> None:
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "dist").mkdir()
+    a = ctx.artifact("*.tar.zst", root="dist")
+    assert a.root == (tmp_path / "dist").resolve()
+
+
+def test_ctx_artifact_absolute_root_must_be_in_allowlist(
+    tmp_path: pathlib.Path,
+) -> None:
+    ctx = _make_ctx(tmp_path)
+    a = ctx.artifact("*.tar.zst", root=str(tmp_path / "scratch"))
+    assert a.root == (tmp_path / "scratch").resolve()
+
+
+def test_ctx_artifact_absolute_root_outside_allowlist_rejected(
+    tmp_path: pathlib.Path,
+) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="not in extra_artifact_roots"):
+        ctx.artifact("*.tar.zst", root="/etc")
+
+
+def test_ctx_artifact_relative_traversal_rejected(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="escapes recipe project root"):
+        ctx.artifact("*.tar.zst", root="../evil")
+
+
+def test_ctx_artifact_empty_glob_rejected(tmp_path: pathlib.Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="glob must be a non-empty"):
+        ctx.artifact("")

--- a/tests/pluginhost/test_recipe_build_ctx.py
+++ b/tests/pluginhost/test_recipe_build_ctx.py
@@ -152,6 +152,18 @@ def test_ctx_artifact_absolute_root_outside_allowlist_rejected(
         ctx.artifact("*.tar.zst", root="/etc")
 
 
+def test_ctx_artifact_absolute_root_subdir_of_allowlist_entry_accepted(
+    tmp_path: pathlib.Path,
+) -> None:
+    # extra_artifact_roots acts as a subtree allow-list per the design
+    # doc: subdirectories of an allowed root should be accepted.
+    ctx = _make_ctx(tmp_path)
+    sub = tmp_path / "scratch" / "sub"
+    sub.mkdir(parents=True)
+    a = ctx.artifact("*.tar.zst", root=str(sub))
+    assert a.root == sub.resolve()
+
+
 def test_ctx_artifact_relative_traversal_rejected(tmp_path: pathlib.Path) -> None:
     ctx = _make_ctx(tmp_path)
     with pytest.raises(RuntimeError, match="escapes recipe project root"):

--- a/tests/pluginhost/test_recipe_build_ctx.py
+++ b/tests/pluginhost/test_recipe_build_ctx.py
@@ -78,7 +78,7 @@ def test_ctx_var_missing_no_default_errors(tmp_path: pathlib.Path) -> None:
 def test_ctx_var_non_string_default_rejected(tmp_path: pathlib.Path) -> None:
     ctx = _make_ctx(tmp_path)
     with pytest.raises(RuntimeError, match="must be a string"):
-        ctx.var("arch", default=42)  # type: ignore[arg-type]
+        ctx.var("arch", default=42)
 
 
 def test_ctx_subprocess_returns_plan(tmp_path: pathlib.Path) -> None:

--- a/tests/ruyipkg/test_build_runner.py
+++ b/tests/ruyipkg/test_build_runner.py
@@ -1,0 +1,214 @@
+"""Tests for the recipe build runner (B7)."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from ruyi.log import RuyiLogger
+from ruyi.ruyipkg.build_runner import (
+    BuildFailure,
+    format_build_report,
+    run_recipe,
+)
+
+
+def _make_project(tmp_path: pathlib.Path, recipe_body: str) -> pathlib.Path:
+    (tmp_path / "ruyi-build-recipes.toml").write_text(
+        'format = "v1"\n[project]\nname = "testproj"\n'
+    )
+    (tmp_path / "out").mkdir(exist_ok=True)
+    recipe_dir = tmp_path / "recipes"
+    recipe_dir.mkdir(exist_ok=True)
+    recipe = recipe_dir / "pkg.star"
+    recipe.write_text(recipe_body)
+    return recipe
+
+
+def test_run_recipe_dry_run(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true', 'hi'])\n"
+        "\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+
+    reports = run_recipe(ruyi_logger, recipe, dry_run=True)
+    assert len(reports) == 1
+    r = reports[0]
+    assert r.build_name == "build_it"
+    assert r.invocations[0].argv == ("/bin/true", "hi")
+    assert r.exit_code == 0
+    assert r.artifacts == ()
+
+
+def test_run_recipe_no_scheduled_builds_errors(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(tmp_path, "RUYI = ruyi_plugin_rev(1)\n")
+    with pytest.raises(RuntimeError, match="scheduled no builds"):
+        run_recipe(ruyi_logger, recipe, dry_run=True)
+
+
+def test_run_recipe_name_filter_selects(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_a(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true', 'a'])\n"
+        "def build_b(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true', 'b'])\n"
+        "\n"
+        "RUYI.build.schedule_build(build_a)\n"
+        "RUYI.build.schedule_build(build_b)\n",
+    )
+    reports = run_recipe(
+        ruyi_logger, recipe, dry_run=True, selected_names=["build_b"]
+    )
+    assert [r.build_name for r in reports] == ["build_b"]
+
+
+def test_run_recipe_name_filter_missing_errors(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_a(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true'])\n"
+        "RUYI.build.schedule_build(build_a)\n",
+    )
+    with pytest.raises(RuntimeError, match="does not define the requested"):
+        run_recipe(
+            ruyi_logger, recipe, dry_run=True, selected_names=["nope"]
+        )
+
+
+def test_run_recipe_user_vars(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    arch = ctx.var('arch')\n"
+        "    return ctx.subprocess(argv = ['/bin/echo', arch])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    reports = run_recipe(
+        ruyi_logger,
+        recipe,
+        dry_run=True,
+        user_vars={"arch": "riscv64"},
+    )
+    assert reports[0].invocations[0].argv == ("/bin/echo", "riscv64")
+
+
+def test_run_recipe_executes_and_collects_artifacts(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    out = tmp_path / "out"
+    out.mkdir(exist_ok=True)
+    artifact = out / "pkg-1.0.tar.zst"
+    artifact.write_bytes(b"dummy")
+
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(\n"
+        "        argv = ['/bin/true'],\n"
+        "        produces = [ctx.artifact(glob = 'pkg-*.tar.zst')],\n"
+        "    )\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+
+    reports = run_recipe(ruyi_logger, recipe)
+    assert len(reports) == 1
+    r = reports[0]
+    assert r.exit_code == 0
+    assert len(r.artifacts) == 1
+    ar = r.artifacts[0]
+    assert ar.path == artifact
+    assert ar.size == 5
+    assert len(ar.sha256) == 64
+    assert len(ar.sha512) == 128
+
+
+def test_run_recipe_missing_artifact_fails(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(\n"
+        "        argv = ['/bin/true'],\n"
+        "        produces = [ctx.artifact(glob = 'nope-*.tar')],\n"
+        "    )\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    with pytest.raises(RuntimeError, match="matched no files"):
+        run_recipe(ruyi_logger, recipe)
+
+
+def test_run_recipe_non_zero_exit_raises_build_failure(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/false'])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    with pytest.raises(BuildFailure) as excinfo:
+        run_recipe(ruyi_logger, recipe)
+    assert excinfo.value.exit_code != 0
+    assert excinfo.value.build_name == "build_it"
+
+
+def test_run_recipe_supports_ruyi_build_load(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    (tmp_path / "ruyi-build-recipes.toml").write_text('format = "v1"\n')
+    (tmp_path / "out").mkdir(exist_ok=True)
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "common.star").write_text("GREETING = 'hi from lib'\n")
+
+    recipe = tmp_path / "recipes" / "pkg.star"
+    recipe.parent.mkdir()
+    recipe.write_text(
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "load('ruyi-build://lib/common.star', 'GREETING')\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/echo', GREETING])\n"
+        "RUYI.build.schedule_build(build_it)\n"
+    )
+
+    reports = run_recipe(ruyi_logger, recipe, dry_run=True)
+    assert reports[0].invocations[0].argv == ("/bin/echo", "hi from lib")
+
+
+def test_format_build_report_is_reasonable(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(argv = ['/bin/true'])\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    reports = run_recipe(ruyi_logger, recipe, dry_run=True)
+    text = format_build_report(reports[0])
+    assert 'build_name = "build_it"' in text
+    assert "[[invocations]]" in text

--- a/tests/ruyipkg/test_build_runner.py
+++ b/tests/ruyipkg/test_build_runner.py
@@ -130,8 +130,8 @@ def test_run_recipe_executes_and_collects_artifacts(
     ar = r.artifacts[0]
     assert ar.path == artifact
     assert ar.size == 5
-    assert len(ar.sha256) == 64
-    assert len(ar.sha512) == 128
+    assert len(ar.checksums["sha256"]) == 64
+    assert len(ar.checksums["sha512"]) == 128
 
 
 def test_run_recipe_missing_artifact_fails(
@@ -204,3 +204,97 @@ def test_format_build_report_is_reasonable(
     text = format_build_report(reports[0])
     assert 'build_name = "build_it"' in text
     assert "[[invocations]]" in text
+
+
+def test_format_build_report_includes_artifacts(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    out = tmp_path / "out"
+    out.mkdir(exist_ok=True)
+    (out / "pkg-1.0.tar.zst").write_bytes(b"dummy")
+
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(\n"
+        "        argv = ['/bin/true'],\n"
+        "        produces = [ctx.artifact(glob = 'pkg-*.tar.zst')],\n"
+        "    )\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    reports = run_recipe(ruyi_logger, recipe)
+    text = format_build_report(reports[0])
+    ar = reports[0].artifacts[0]
+    assert "[[artifacts]]" in text
+    assert f'path = "{ar.path}"' in text
+    assert f"size = {ar.size}" in text
+    assert f'sha256 = "{ar.checksums["sha256"]}"' in text
+    assert f'sha512 = "{ar.checksums["sha512"]}"' in text
+
+
+def test_run_recipe_rejects_non_invocation_return(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return 'not-an-invocation'\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    with pytest.raises(RuntimeError, match="expected Invocation"):
+        run_recipe(ruyi_logger, recipe, dry_run=True)
+
+
+def test_run_recipe_rejects_list_with_non_invocation(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return [ctx.subprocess(argv = ['/bin/true']), 42]\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    with pytest.raises(RuntimeError, match="expected Invocation"):
+        run_recipe(ruyi_logger, recipe, dry_run=True)
+
+
+def test_run_recipe_rejects_empty_list(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return []\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    with pytest.raises(RuntimeError, match="empty list"):
+        run_recipe(ruyi_logger, recipe, dry_run=True)
+
+
+def test_run_recipe_output_dir_override(
+    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
+) -> None:
+    override_out = tmp_path / "override_out"
+    override_out.mkdir()
+    (override_out / "overridden.tar.zst").write_bytes(b"ok")
+
+    recipe = _make_project(
+        tmp_path,
+        "RUYI = ruyi_plugin_rev(1)\n"
+        "def build_it(ctx):\n"
+        "    return ctx.subprocess(\n"
+        "        argv = ['/bin/true'],\n"
+        "        produces = [ctx.artifact(glob = '*.tar.zst')],\n"
+        "    )\n"
+        "RUYI.build.schedule_build(build_it)\n",
+    )
+    reports = run_recipe(ruyi_logger, recipe, output_dir_override=override_out)
+    assert len(reports) == 1
+    assert len(reports[0].artifacts) == 1
+    assert (
+        reports[0].artifacts[0].path == (override_out / "overridden.tar.zst").resolve()
+    )

--- a/tests/ruyipkg/test_build_runner.py
+++ b/tests/ruyipkg/test_build_runner.py
@@ -26,9 +26,7 @@ def _make_project(tmp_path: pathlib.Path, recipe_body: str) -> pathlib.Path:
     return recipe
 
 
-def test_run_recipe_dry_run(
-    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
-) -> None:
+def test_run_recipe_dry_run(tmp_path: pathlib.Path, ruyi_logger: RuyiLogger) -> None:
     recipe = _make_project(
         tmp_path,
         "RUYI = ruyi_plugin_rev(1)\n"
@@ -69,9 +67,7 @@ def test_run_recipe_name_filter_selects(
         "RUYI.build.schedule_build(build_a)\n"
         "RUYI.build.schedule_build(build_b)\n",
     )
-    reports = run_recipe(
-        ruyi_logger, recipe, dry_run=True, selected_names=["build_b"]
-    )
+    reports = run_recipe(ruyi_logger, recipe, dry_run=True, selected_names=["build_b"])
     assert [r.build_name for r in reports] == ["build_b"]
 
 
@@ -86,14 +82,10 @@ def test_run_recipe_name_filter_missing_errors(
         "RUYI.build.schedule_build(build_a)\n",
     )
     with pytest.raises(RuntimeError, match="does not define the requested"):
-        run_recipe(
-            ruyi_logger, recipe, dry_run=True, selected_names=["nope"]
-        )
+        run_recipe(ruyi_logger, recipe, dry_run=True, selected_names=["nope"])
 
 
-def test_run_recipe_user_vars(
-    tmp_path: pathlib.Path, ruyi_logger: RuyiLogger
-) -> None:
+def test_run_recipe_user_vars(tmp_path: pathlib.Path, ruyi_logger: RuyiLogger) -> None:
     recipe = _make_project(
         tmp_path,
         "RUYI = ruyi_plugin_rev(1)\n"

--- a/tests/ruyipkg/test_recipe_project.py
+++ b/tests/ruyipkg/test_recipe_project.py
@@ -1,0 +1,164 @@
+import os
+import pathlib
+
+import pytest
+
+from ruyi.ruyipkg.recipe_project import (
+    MARKER_FILENAME,
+    RecipeProject,
+    RecipeProjectError,
+    discover_recipe_project,
+    safe_join,
+)
+
+
+def _write_marker(root: pathlib.Path, body: str) -> None:
+    (root / MARKER_FILENAME).write_text(body)
+
+
+def test_discover_from_immediate_parent(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v1"\n[project]\nname = "demo"\n')
+    recipe = tmp_path / "foo.star"
+    recipe.write_text("")
+
+    rp = discover_recipe_project(recipe)
+    assert rp.root == tmp_path.resolve()
+    assert rp.name == "demo"
+    assert rp.output_dir == (tmp_path / "out").resolve()
+    assert rp.extra_artifact_roots == ()
+
+
+def test_discover_walks_up_parents(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v1"\n')
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    recipe = nested / "x.star"
+    recipe.write_text("")
+
+    rp = discover_recipe_project(recipe)
+    assert rp.root == tmp_path.resolve()
+    # Default name falls back to root dir name.
+    assert rp.name == tmp_path.name
+
+
+def test_discover_missing_marker(tmp_path: pathlib.Path) -> None:
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="no ruyi-build-recipes.toml"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_missing_recipe_file(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(RecipeProjectError, match="recipe file not found"):
+        discover_recipe_project(tmp_path / "nope.star")
+
+
+def test_discover_malformed_toml(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, "not = valid = toml")
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="malformed"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_unsupported_format(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v2"\n')
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="unsupported or missing 'format'"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_custom_output_dir_and_extras(tmp_path: pathlib.Path) -> None:
+    _write_marker(
+        tmp_path,
+        'format = "v1"\n'
+        "[project]\n"
+        'name = "demo"\n'
+        'output_dir = "dist"\n'
+        f'extra_artifact_roots = ["{tmp_path.as_posix()}/scratch"]\n',
+    )
+    (tmp_path / "scratch").mkdir()
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+
+    rp = discover_recipe_project(recipe)
+    assert rp.output_dir == (tmp_path / "dist").resolve()
+    assert rp.extra_artifact_roots == ((tmp_path / "scratch").resolve(),)
+
+
+def test_discover_absolute_output_dir_rejected(tmp_path: pathlib.Path) -> None:
+    _write_marker(
+        tmp_path,
+        'format = "v1"\n[project]\noutput_dir = "/abs"\n',
+    )
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="output_dir must be a project-relative"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_traversing_output_dir_rejected(tmp_path: pathlib.Path) -> None:
+    _write_marker(
+        tmp_path,
+        'format = "v1"\n[project]\noutput_dir = "../out"\n',
+    )
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="escapes the project root"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_relative_extra_artifact_root_rejected(tmp_path: pathlib.Path) -> None:
+    _write_marker(
+        tmp_path,
+        'format = "v1"\n[project]\nextra_artifact_roots = ["scratch"]\n',
+    )
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="must be absolute"):
+        discover_recipe_project(recipe)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlinks are POSIX-flavored here")
+def test_discover_symlink_escape_rejected(tmp_path: pathlib.Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _write_marker(project, 'format = "v1"\n')
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_recipe = outside / "x.star"
+    real_recipe.write_text("")
+
+    link = project / "x.star"
+    link.symlink_to(real_recipe)
+
+    with pytest.raises(RecipeProjectError, match="escapes its project root"):
+        discover_recipe_project(link)
+
+
+def test_safe_join_ok(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "lib").mkdir()
+    target = tmp_path / "lib" / "docker.star"
+    target.write_text("")
+    assert safe_join(tmp_path, "lib/docker.star") == target.resolve()
+
+
+def test_safe_join_rejects_traversal(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(RecipeProjectError, match="escapes recipe project root"):
+        safe_join(tmp_path, "../evil")
+
+
+def test_safe_join_rejects_absolute(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(RecipeProjectError, match="absolute paths are not allowed"):
+        safe_join(tmp_path, "/etc/passwd")
+
+
+def test_recipe_project_marker_path(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v1"\n')
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    rp = discover_recipe_project(recipe)
+    assert isinstance(rp, RecipeProject)
+    assert rp.marker_path == tmp_path.resolve() / MARKER_FILENAME

--- a/tests/ruyipkg/test_recipe_project.py
+++ b/tests/ruyipkg/test_recipe_project.py
@@ -94,7 +94,9 @@ def test_discover_absolute_output_dir_rejected(tmp_path: pathlib.Path) -> None:
     )
     recipe = tmp_path / "x.star"
     recipe.write_text("")
-    with pytest.raises(RecipeProjectError, match="output_dir must be a project-relative"):
+    with pytest.raises(
+        RecipeProjectError, match="output_dir must be a project-relative"
+    ):
         discover_recipe_project(recipe)
 
 

--- a/tests/ruyipkg/test_recipe_project.py
+++ b/tests/ruyipkg/test_recipe_project.py
@@ -164,3 +164,53 @@ def test_recipe_project_marker_path(tmp_path: pathlib.Path) -> None:
     rp = discover_recipe_project(recipe)
     assert isinstance(rp, RecipeProject)
     assert rp.marker_path == tmp_path.resolve() / MARKER_FILENAME
+
+
+def test_discover_invalid_project_not_table(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v1"\nproject = 1\n')
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match=r"\[project\] must be a table"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_invalid_project_name_empty(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v1"\n[project]\nname = ""\n')
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="project.name"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_invalid_project_name_non_string(tmp_path: pathlib.Path) -> None:
+    _write_marker(tmp_path, 'format = "v1"\n[project]\nname = 123\n')
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="project.name"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_invalid_extra_artifact_roots_non_list(
+    tmp_path: pathlib.Path,
+) -> None:
+    _write_marker(
+        tmp_path,
+        'format = "v1"\n[project]\nextra_artifact_roots = "scratch"\n',
+    )
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="extra_artifact_roots"):
+        discover_recipe_project(recipe)
+
+
+def test_discover_invalid_extra_artifact_roots_non_string_item(
+    tmp_path: pathlib.Path,
+) -> None:
+    _write_marker(
+        tmp_path,
+        'format = "v1"\n[project]\nextra_artifact_roots = ["/ok", 1]\n',
+    )
+    recipe = tmp_path / "x.star"
+    recipe.write_text("")
+    with pytest.raises(RecipeProjectError, match="extra_artifact_roots"):
+        discover_recipe_project(recipe)


### PR DESCRIPTION
## Summary by Sourcery

Add support for building packages from Starlark-based build recipes via a new `ruyi admin build-package` command and dedicated build-recipe host APIs.

New Features:
- Introduce a build-recipe execution pipeline that discovers recipe projects, loads Starlark recipes, schedules builds, and executes declared subprocess invocations to produce artifacts.
- Add the `ruyi admin build-package` CLI subcommand to run a specified recipe file with support for user variables, build selection, dry runs, and output directory overrides.
- Expose a `build-recipe-v1` capability and `RUYI.build` API (including scheduling builds and recipe build context helpers) for Starlark modules loaded in build-recipe mode.
- Add new `ruyi-build://` and `ruyi-build-data://` load path schemes for accessing code and data relative to a recipe project root.

Enhancements:
- Extend the plugin host context and loader with explicit load modes, per-mode capabilities, and support for tracking scheduled builds registered during recipe loading.
- Guard subprocess execution and feature availability based on host context capabilities, tightening separation between command plugins and build recipes.

Documentation:
- Document the build recipe design and workflow in a new build-recipes design document and link it from the main documentation index.

Tests:
- Add unit, integration, and path-resolution tests covering recipe project discovery, build-recipe APIs, load-path handling, and the `ruyi admin build-package` command.