### PR TITLE
Harden the plugin host a bit more

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -319,18 +319,18 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.12"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
+    {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -600,63 +600,66 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.20.1"
+version = "1.20.2"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mypy-1.20.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3ba5d1e712ada9c3b6223dcbc5a31dac334ed62991e5caa17bcf5a4ddc349af0"},
-    {file = "mypy-1.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e731284c117b0987fb1e6c5013a56f33e7faa1fce594066ab83876183ce1c66"},
-    {file = "mypy-1.20.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f8e945b872a05f4fbefabe2249c0b07b6b194e5e11a86ebee9edf855de09806c"},
-    {file = "mypy-1.20.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fc88acef0dc9b15246502b418980478c1bfc9702057a0e1e7598d01a7af8937"},
-    {file = "mypy-1.20.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:14911a115c73608f155f648b978c5055d16ff974e6b1b5512d7fedf4fa8b15c6"},
-    {file = "mypy-1.20.1-cp310-cp310-win_amd64.whl", hash = "sha256:76d9b4c992cca3331d9793ef197ae360ea44953cf35beb2526e95b9e074f2866"},
-    {file = "mypy-1.20.1-cp310-cp310-win_arm64.whl", hash = "sha256:b408722f80be44845da555671a5ef3a0c63f51ca5752b0c20e992dc9c0fbd3cd"},
-    {file = "mypy-1.20.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c01eb9bac2c6a962d00f9d23421cd2913840e65bba365167d057bd0b4171a92e"},
-    {file = "mypy-1.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55d12ddbd8a9cac5b276878bd534fa39fff5bf543dc6ae18f25d30c8d7d27fca"},
-    {file = "mypy-1.20.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0aa322c1468b6cdfc927a44ce130f79bb44bcd34eb4a009eb9f96571fd80955"},
-    {file = "mypy-1.20.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f8bc95899cf676b6e2285779a08a998cc3a7b26f1026752df9d2741df3c79e8"},
-    {file = "mypy-1.20.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:47c2b90191a870a04041e910277494b0d92f0711be9e524d45c074fe60c00b65"},
-    {file = "mypy-1.20.1-cp311-cp311-win_amd64.whl", hash = "sha256:9857dc8d2ec1a392ffbda518075beb00ac58859979c79f9e6bdcb7277082c2f2"},
-    {file = "mypy-1.20.1-cp311-cp311-win_arm64.whl", hash = "sha256:09d8df92bb25b6065ab91b178da843dda67b33eb819321679a6e98a907ce0e10"},
-    {file = "mypy-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:36ee2b9c6599c230fea89bbd79f401f9f9f8e9fcf0c777827789b19b7da90f51"},
-    {file = "mypy-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fba3fb0968a7b48806b0c90f38d39296f10766885a94c83bd21399de1e14eb28"},
-    {file = "mypy-1.20.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef1415a637cd3627d6304dfbeddbadd21079dafc2a8a753c477ce4fc0c2af54f"},
-    {file = "mypy-1.20.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef3461b1ad5cd446e540016e90b5984657edda39f982f4cc45ca317b628f5a37"},
-    {file = "mypy-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:542dd63c9e1339b6092eb25bd515f3a32a1453aee8c9521d2ddb17dacd840237"},
-    {file = "mypy-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d55c7cd8ca22e31f93af2a01160a9e95465b5878de23dba7e48116052f20a8d"},
-    {file = "mypy-1.20.1-cp312-cp312-win_arm64.whl", hash = "sha256:f5b84a79070586e0d353ee07b719d9d0a4aa7c8ee90c0ea97747e98cbe193019"},
-    {file = "mypy-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f3886c03e40afefd327bd70b3f634b39ea82e87f314edaa4d0cce4b927ddcc1"},
-    {file = "mypy-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e860eb3904f9764e83bafd70c8250bdffdc7dde6b82f486e8156348bf7ceb184"},
-    {file = "mypy-1.20.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4b5aac6e785719da51a84f5d09e9e843d473170a9045b1ea7ea1af86225df4b"},
-    {file = "mypy-1.20.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f37b6cd0fe2ad3a20f05ace48ca3523fc52ff86940e34937b439613b6854472e"},
-    {file = "mypy-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4bbb0f6b54ce7cc350ef4a770650d15fa70edd99ad5267e227133eda9c94218"},
-    {file = "mypy-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:c3dc20f8ec76eecd77148cdd2f1542ed496e51e185713bf488a414f862deb8f2"},
-    {file = "mypy-1.20.1-cp313-cp313-win_arm64.whl", hash = "sha256:a9d62bbac5d6d46718e2b0330b25e6264463ed832722b8f7d4440ff1be3ca895"},
-    {file = "mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12"},
-    {file = "mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe"},
-    {file = "mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08"},
-    {file = "mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572"},
-    {file = "mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6"},
-    {file = "mypy-1.20.1-cp314-cp314-win_amd64.whl", hash = "sha256:0131edd7eba289973d1ba1003d1a37c426b85cdef76650cd02da6420898a5eb3"},
-    {file = "mypy-1.20.1-cp314-cp314-win_arm64.whl", hash = "sha256:33f02904feb2c07e1fdf7909026206396c9deeb9e6f34d466b4cfedb0aadbbe4"},
-    {file = "mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a"},
-    {file = "mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986"},
-    {file = "mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a"},
-    {file = "mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9"},
-    {file = "mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02"},
-    {file = "mypy-1.20.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a0c17fbd746d38c70cbc42647cfd884f845a9708a4b160a8b4f7e70d41f4d7fa"},
-    {file = "mypy-1.20.1-cp314-cp314t-win_arm64.whl", hash = "sha256:db2cb89654626a912efda69c0d5c1d22d948265e2069010d3dde3abf751c7d08"},
-    {file = "mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06"},
-    {file = "mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804"},
+    {file = "mypy-1.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cf5a4db6dca263010e2c7bff081c89383c72d187ba2cf4c44759aac970e2f0c4"},
+    {file = "mypy-1.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b0e817b518bff7facd7f85ea05b643ad8bdcce684cf29784987b0a7c8e1f997"},
+    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97d7b9a485b40f8ca425460e89bf1da2814625b2da627c0dcc6aa46c92631d14"},
+    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e1c12f6d2db3d78b909b5f77513c11eb7f2dd2782b96a3ab6dffc7d44575c99"},
+    {file = "mypy-1.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:89dce27e142d25ffbc154c1819383b69f2e9234dc4ed4766f42e0e8cb264ab5c"},
+    {file = "mypy-1.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:f376e37f9bf2a946872fc5fd1199c99310748e3c26c7a26683f13f8bdb756cbd"},
+    {file = "mypy-1.20.2-cp310-cp310-win_arm64.whl", hash = "sha256:6e2b469efd811707bc530fd1effef0f5d6eebcb7fe376affae69025da4b979a2"},
+    {file = "mypy-1.20.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4077797a273e56e8843d001e9dfe4ba10e33323d6ade647ff260e5cd97d9758c"},
+    {file = "mypy-1.20.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdecf62abcc4292500d7858aeae87a1f8f1150f4c4dd08fb0b336ee79b2a6df3"},
+    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c566c3a88b6ece59b3d70f65bedef17304f48eb52ff040a6a18214e1917b3254"},
+    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0deb80d062b2479f2c87ae568f89845afc71d11bc41b04179e58165fd9f31e98"},
+    {file = "mypy-1.20.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bba9ad231e92a3e424b3e56b65aa17704993425bba97e302c832f9466bb85bac"},
+    {file = "mypy-1.20.2-cp311-cp311-win_amd64.whl", hash = "sha256:baf593f2765fa3a6b1ef95807dbaa3d25b594f6a52adcc506a6b9cb115e1be67"},
+    {file = "mypy-1.20.2-cp311-cp311-win_arm64.whl", hash = "sha256:20175a1c0f49863946ec20b7f63255768058ac4f07d2b9ded6a6b46cfb5a9100"},
+    {file = "mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b"},
+    {file = "mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4"},
+    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6"},
+    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066"},
+    {file = "mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102"},
+    {file = "mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9"},
+    {file = "mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58"},
+    {file = "mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026"},
+    {file = "mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943"},
+    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517"},
+    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15"},
+    {file = "mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee"},
+    {file = "mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f"},
+    {file = "mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330"},
+    {file = "mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30"},
+    {file = "mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924"},
+    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb"},
+    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc"},
+    {file = "mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558"},
+    {file = "mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8"},
+    {file = "mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3"},
+    {file = "mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609"},
+    {file = "mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2"},
+    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c"},
+    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744"},
+    {file = "mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6"},
+    {file = "mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec"},
+    {file = "mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382"},
+    {file = "mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563"},
+    {file = "mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665"},
 ]
 
 [package.dependencies]
 librt = {version = ">=0.8.0", markers = "platform_python_implementation != \"PyPy\""}
 mypy_extensions = ">=1.0.0"
 pathspec = ">=1.0.0"
-typing_extensions = ">=4.6.0"
+typing_extensions = [
+    {version = ">=4.6.0", markers = "python_version < \"3.15\""},
+    {version = ">=4.14.0", markers = "python_version >= \"3.15\""},
+]
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -286,7 +286,7 @@ class _GatedFeatureError(Exception):
     bare node type.
     """
 
-    def __init__(self, node: ast.stmt | ast.expr, feature: str) -> None:
+    def __init__(self, node: ast.stmt | ast.expr | ast.arg, feature: str) -> None:
         super().__init__(feature)
         self.node = node
         self.feature = feature
@@ -355,6 +355,12 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         if node.returns is not None:
             raise _GatedFeatureError(node.returns, "return type annotation")
         _reject_annotated_args(node.args)
+        # Starlark's Parameter grammar has no ``/`` marker (PEP 570), so
+        # positional-only parameters have no way to be expressed there.
+        if node.args.posonlyargs:
+            raise _GatedFeatureError(
+                node.args.posonlyargs[0], "positional-only parameter (`/`)"
+            )
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -397,6 +397,15 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
             raise _GatedFeatureError(node, "matrix-multiplication assignment (`@=`)")
         self.generic_visit(node)
 
+    def visit_Compare(self, node: ast.Compare) -> None:
+        # Starlark spec: "Comparison operators, ``in``, and ``not in`` are
+        # non-associative, so the parser will not accept ``0 <= i < n``."
+        # Reject chained comparisons (more than one operator in a single
+        # Compare node) accordingly.
+        if len(node.ops) > 1:
+            raise _GatedFeatureError(node, "chained comparison")
+        self.generic_visit(node)
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -310,6 +310,27 @@ def _reject_annotated_args(args: ast.arguments) -> None:
             raise _GatedFeatureError(arg.annotation, "parameter type annotation")
 
 
+def _find_slice_assign_target(target: ast.expr) -> ast.Subscript | None:
+    """Return the offending ``Subscript`` node if ``target`` is, or
+    directly contains within a top-level tuple/list unpacking, a
+    subscript whose slice is an ``ast.Slice``. Return ``None`` otherwise.
+
+    The check is deliberately shallow: Starlark's spec says "Starlark
+    does not allow a slice expression to be the target of an assignment,
+    although it may appear as a subexpression in the target," and
+    forms like ``a[b[c:d]] = x`` are explicitly legal. We therefore
+    only inspect the target spine itself (tuple/list unpacking), not
+    arbitrary sub-expressions underneath a Subscript's value.
+    """
+    if isinstance(target, ast.Subscript) and isinstance(target.slice, ast.Slice):
+        return target
+    if isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            if (found := _find_slice_assign_target(elt)) is not None:
+                return found
+    return None
+
+
 class GatedLanguageFeaturesPass(ast.NodeVisitor):
     """Reject Python syntax that has no Starlark analogue.
 
@@ -408,6 +429,16 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # Same reasoning for the in-place form ``@=``.
         if isinstance(node.op, ast.MatMult):
             raise _GatedFeatureError(node, "matrix-multiplication assignment (`@=`)")
+        # Starlark forbids a slice expression on the LHS of an assignment.
+        if (bad := _find_slice_assign_target(node.target)) is not None:
+            raise _GatedFeatureError(bad, "slice as assignment target")
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # Starlark forbids a slice expression on the LHS of an assignment.
+        for target in node.targets:
+            if (bad := _find_slice_assign_target(target)) is not None:
+                raise _GatedFeatureError(bad, "slice as assignment target")
         self.generic_visit(node)
 
     def visit_Compare(self, node: ast.Compare) -> None:

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -1,3 +1,76 @@
+"""Unsandboxed Python plugin host.
+
+Rationale
+---------
+
+Ruyi plugins were originally authored in Starlark and executed through
+``xingque`` (a binding to ``starlark-rust``), which provided genuine
+language-level isolation. That backend was dropped in October 2024;
+see commits ``bc458ce`` (the introduction of this file), ``a9d66bd``
+(making it the default), and ``2b7c24d`` / ``9e5abe1`` (removal of the
+Starlark backend).
+
+The stated reason in ``bc458ce`` is that the plugin surface was
+restricted to standard Python 3 rather than any dialect of it. The
+underlying project-level goal is broader: the whole of RuyiSDK is kept
+to Python and shell so that onboarding is trivial, so that loss of
+project staff is survivable, and so that third-party commercial
+partners can take over maintenance of their own forks without being
+blocked by any non-trivial piece of code in a less widely known
+language. Reintroducing Starlark -- or any other embedded language or
+Rust-backed sandbox -- would reintroduce exactly the kind of
+specialist-knowledge cliff this policy exists to avoid, and is
+therefore not on the table regardless of its technical merits.
+
+Threat model and non-goals
+--------------------------
+
+This module is intentionally *not* a sandbox. Plugin sources are
+parsed, AST-linted, compiled, and ``exec``-ed in the host interpreter
+with a curated ``__builtins__`` mapping. A malicious plugin can escape
+trivially.
+
+The original justification, as recorded in ``bc458ce`` in 2024, was:
+
+    No "outsiders" are involved in plugin creation yet, and attacks
+    from "insiders" are not going to be thwarted by code-level
+    sandboxing alone.
+
+That premise has since lapsed and the quote should be read as
+historical rather than current. Third-party addon repositories are a
+supported feature, which means plugin code loaded by Ruyi can now
+originate from authors outside the project. An unsandboxed Python
+runtime provides no meaningful defence against a hostile or
+compromised third-party addon; in particular, the capability set in
+``PluginHostContext`` (``call-subprocess-v1``, ``build-recipe-v1``,
+``i18n-v1``, ...) is an API-shape boundary, not a security boundary,
+and is trivially escapable from in-process Python.
+
+The present mitigations against this are operational rather than
+technical: a prominent warning and explicit user confirmation on
+``ruyi repo add``, and the expectation that users extend trust to
+third-party repos on the same footing as any other third-party code
+they choose to run. Revisiting this with an actual sandbox (process
+isolation, a reintroduced Starlark backend, or another mechanism) is
+out of scope of this module and currently gated on project-level
+decisions rather than technical ones; see
+https://github.com/ruyisdk/ruyi/issues/444 for tracking.
+
+Recursion detection, resource limits, timeouts, and filesystem or
+network isolation are likewise out of scope here; they are not
+soundly achievable with pure AST inspection plus ``exec`` in CPython.
+
+What the module does enforce, and why, is documented on the
+individual enforcement points themselves: ``BUILTINS_TO_EXPOSE``,
+``GatedLanguageFeaturesPass``, and ``_load_stmt_helper`` below, plus
+the ``PluginHostContext`` capability set in ``api.py`` /
+``build_api.py``. The unifying goal of those checks is not security
+but *Starlark portability*: keeping plugin sources close to the shape
+of the original Starlark subset so that a future move back to a real
+Starlark runtime -- should the project-level policy above ever shift
+-- would not require rewriting every in-tree plugin.
+"""
+
 import ast
 import builtins
 import inspect
@@ -30,6 +103,15 @@ class UnsandboxedTrivialEvaluator:
         raise RuntimeError(f"the Python value {function!r} is not callable")
 
 
+# The set of Python builtins exposed to plugin code in place of the real
+# ``builtins`` module. Membership criterion: the name must either exist in
+# Starlark or map cleanly onto a Starlark equivalent, so that keeping a
+# plugin portable to a future Starlark backend does not require giving up
+# any builtin listed here. Introspection / reflection / dynamic-eval
+# builtins (``eval``, ``exec``, ``compile``, ``globals``, ``locals``,
+# ``vars``, ``__import__``, ``open``, ...) are deliberately absent for the
+# same reason: they have no Starlark counterpart. This is a portability
+# fence, not a security boundary -- see the module docstring.
 BUILTINS_TO_EXPOSE: Final = {
     k: getattr(builtins, k)
     for k in [
@@ -110,6 +192,20 @@ class UnsandboxedRuyiPluginLoader(BasePluginLoader[UnsandboxedModuleDict]):
             *values_to_bind: str,
             **renamed_values_to_bind: str,
         ) -> None:
+            """Starlark-style ``load()`` exposed to plugins.
+
+            This is deliberately *not* a wrapper over Python ``import``:
+            it mirrors Starlark's ``load()`` statement so that plugin
+            sources remain portable to a real Starlark backend. In
+            particular, it binds names by injection into the caller's
+            frame (matching Starlark semantics), and it refuses to bind
+            names beginning with ``_``, matching Starlark's rule that
+            underscore-prefixed symbols are module-private.
+
+            ``import`` / ``from ... import ...`` are separately rejected
+            by ``GatedLanguageFeaturesPass`` so that ``load()`` is the
+            only way for plugins to pull in other modules.
+            """
             mod = sub_loader.load(spec)
 
             curr_frame = inspect.currentframe()
@@ -165,11 +261,50 @@ class UnsandboxedRuyiPluginLoader(BasePluginLoader[UnsandboxedModuleDict]):
 
 
 def lint_module(mod: ast.Module) -> None:
+    """Run best-effort parse-time lints over a plugin module AST.
+
+    Currently this runs only ``GatedLanguageFeaturesPass``; additional
+    best-effort static checks (for example a call-graph pass flagging
+    obvious direct or mutual recursion) may be layered in over time.
+    Anything added here should be understood as a lint, not a soundness
+    guarantee -- see the module docstring for why real enforcement is
+    out of scope.
+    """
     if node := GatedLanguageFeaturesPass().visit(mod):
         raise RuntimeError(f"line {node.lineno}: language feature is gated")
 
 
 class GatedLanguageFeaturesPass(ast.NodeVisitor):
+    """Reject Python syntax that has no Starlark analogue.
+
+    Each ``visit_*`` override below names one construct that is gated
+    at parse time. The selection criterion is *Starlark portability*,
+    not safety: a feature is gated if accepting it would make it
+    materially harder to move plugin sources back to a real Starlark
+    runtime later. Rejected constructs include, among others:
+
+    * ``NamedExpr`` (walrus) -- not in Starlark.
+    * ``Raise``, ``Assert`` -- Starlark uses ``fail()`` for errors.
+    * ``Import`` / ``ImportFrom`` -- Starlark uses ``load()``; see
+      ``_load_stmt_helper``.
+    * ``Try`` / ``TryStar`` / ``With`` -- no Starlark equivalents.
+    * ``Match`` -- not in Starlark.
+    * ``Yield`` / ``YieldFrom`` -- Starlark has no generators.
+    * ``Global`` / ``Nonlocal`` -- Starlark's scoping rules differ.
+    * ``ClassDef`` -- Starlark has no user-defined classes.
+    * ``AsyncFunctionDef`` / ``Await`` / ``AsyncFor`` / ``AsyncWith``
+      -- Starlark has no async model.
+
+    The gate is necessarily best-effort: CPython's grammar is larger
+    than Starlark's and evolves between releases. When a new language
+    feature lands in CPython, the default choice should be to add it
+    here -- anything not already required by an existing plugin is
+    cheaper to forbid now than to un-ship later.
+
+    This is a portability fence, not a security boundary; see the
+    module docstring.
+    """
+
     def visit(self, node: ast.AST) -> ast.expr | ast.stmt | None:
         return cast(ast.expr | ast.stmt | None, super().visit(node))
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -77,7 +77,7 @@ import inspect
 import os
 import pathlib
 from types import CodeType
-from typing import Callable, Final, MutableMapping, NoReturn, TYPE_CHECKING, cast
+from typing import Callable, Final, MutableMapping, NoReturn, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing_extensions import Buffer
@@ -270,8 +270,26 @@ def lint_module(mod: ast.Module) -> None:
     guarantee -- see the module docstring for why real enforcement is
     out of scope.
     """
-    if node := GatedLanguageFeaturesPass().visit(mod):
-        raise RuntimeError(f"line {node.lineno}: language feature is gated")
+    try:
+        GatedLanguageFeaturesPass().visit(mod)
+    except _GatedFeatureError as e:
+        raise RuntimeError(
+            f"line {e.node.lineno}: {e.feature} is not allowed in plugin code"
+        ) from e
+
+
+class _GatedFeatureError(Exception):
+    """Internal signal raised by ``GatedLanguageFeaturesPass`` when it
+    encounters a gated construct. Carries the offending AST node (for
+    its line number) and a short human-readable name of the feature,
+    so ``lint_module`` can surface a useful diagnostic instead of the
+    bare node type.
+    """
+
+    def __init__(self, node: ast.stmt | ast.expr, feature: str) -> None:
+        super().__init__(feature)
+        self.node = node
+        self.feature = feature
 
 
 class GatedLanguageFeaturesPass(ast.NodeVisitor):
@@ -305,76 +323,56 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
     module docstring.
     """
 
-    def visit(self, node: ast.AST) -> ast.expr | ast.stmt | None:
-        return cast(ast.expr | ast.stmt | None, super().visit(node))
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        raise _GatedFeatureError(node, "walrus operator (`:=`)")
 
-    def generic_visit(self, node: ast.AST) -> ast.expr | ast.stmt | None:
-        """Traverses all types of nodes, bailing if non-minimal language
-        features are found."""
+    def visit_Raise(self, node: ast.Raise) -> None:
+        raise _GatedFeatureError(node, "`raise` statement")
 
-        for _, value in ast.iter_fields(node):
-            if isinstance(value, list):
-                for item in value:
-                    if isinstance(item, ast.AST):
-                        if x := self.visit(item):
-                            return x
-            elif isinstance(value, ast.AST):
-                if x := self.visit(value):
-                    return x
-        return None
+    def visit_Assert(self, node: ast.Assert) -> None:
+        raise _GatedFeatureError(node, "`assert` statement")
 
-    def visit_NamedExpr(self, node: ast.NamedExpr) -> ast.NamedExpr:
-        return node
+    def visit_Import(self, node: ast.Import) -> None:
+        raise _GatedFeatureError(node, "`import` statement")
 
-    def visit_Raise(self, node: ast.Raise) -> ast.Raise:
-        return node
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        raise _GatedFeatureError(node, "`from ... import ...` statement")
 
-    def visit_Assert(self, node: ast.Assert) -> ast.Assert:
-        return node
+    def visit_Try(self, node: ast.Try) -> None:
+        raise _GatedFeatureError(node, "`try` statement")
 
-    def visit_Import(self, node: ast.Import) -> ast.Import:
-        return node
+    def visit_TryStar(self, node: ast.TryStar) -> None:
+        raise _GatedFeatureError(node, "`try ... except*` statement")
 
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.ImportFrom:
-        return node
+    def visit_With(self, node: ast.With) -> None:
+        raise _GatedFeatureError(node, "`with` statement")
 
-    def visit_Try(self, node: ast.Try) -> ast.Try:
-        return node
+    def visit_Match(self, node: ast.Match) -> None:
+        raise _GatedFeatureError(node, "`match` statement")
 
-    def visit_TryStar(self, node: ast.TryStar) -> ast.TryStar:
-        return node
+    def visit_Yield(self, node: ast.Yield) -> None:
+        raise _GatedFeatureError(node, "`yield` expression")
 
-    def visit_With(self, node: ast.With) -> ast.With:
-        return node
+    def visit_YieldFrom(self, node: ast.YieldFrom) -> None:
+        raise _GatedFeatureError(node, "`yield from` expression")
 
-    def visit_Match(self, node: ast.Match) -> ast.Match:
-        return node
+    def visit_Global(self, node: ast.Global) -> None:
+        raise _GatedFeatureError(node, "`global` statement")
 
-    def visit_Yield(self, node: ast.Yield) -> ast.Yield:
-        return node
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        raise _GatedFeatureError(node, "`nonlocal` statement")
 
-    def visit_YieldFrom(self, node: ast.YieldFrom) -> ast.YieldFrom:
-        return node
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        raise _GatedFeatureError(node, "`class` definition")
 
-    def visit_Global(self, node: ast.Global) -> ast.Global:
-        return node
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        raise _GatedFeatureError(node, "`async def` function")
 
-    def visit_Nonlocal(self, node: ast.Nonlocal) -> ast.Nonlocal:
-        return node
+    def visit_Await(self, node: ast.Await) -> None:
+        raise _GatedFeatureError(node, "`await` expression")
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
-        return node
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        raise _GatedFeatureError(node, "`async for` loop")
 
-    def visit_AsyncFunctionDef(
-        self, node: ast.AsyncFunctionDef
-    ) -> ast.AsyncFunctionDef:
-        return node
-
-    def visit_Await(self, node: ast.Await) -> ast.Await:
-        return node
-
-    def visit_AsyncFor(self, node: ast.AsyncFor) -> ast.AsyncFor:
-        return node
-
-    def visit_AsyncWith(self, node: ast.AsyncWith) -> ast.AsyncWith:
-        return node
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        raise _GatedFeatureError(node, "`async with` statement")

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -361,6 +361,24 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
     runtime later. Rejected constructs include, among others:
 
     * ``NamedExpr`` (walrus) -- not in Starlark.
+    * Decorators, return type annotations, parameter annotations and
+      positional-only parameters on ``FunctionDef`` -- none of these
+      have a production in Starlark's ``DefStmt`` or Parameter grammar.
+    * ``AnnAssign`` (variable type annotations) -- no analogue.
+    * ``JoinedStr`` (f-strings) -- Starlark has only plain string and
+      bytes literals.
+    * ``Set`` / ``SetComp`` -- Starlark has no set type or set
+      comprehensions.
+    * ``GeneratorExp`` -- Starlark has no generators.
+    * ``Delete`` (``del`` statement) -- not in Starlark.
+    * ``BinOp`` / ``AugAssign`` with ``MatMult`` (``@``, ``@=``) --
+      not in Starlark's operator list.
+    * ``Compare`` with more than one operator (chained comparisons) --
+      Starlark's comparison operators are non-associative.
+    * ``While`` -- not in Starlark's Statement grammar.
+    * Slice expressions in assignment targets, and starred expressions
+      in assignment / loop-variable targets -- forbidden by Starlark's
+      ``AssignStmt`` and ``LoopVariables`` grammars respectively.
     * ``Raise``, ``Assert`` -- Starlark uses ``fail()`` for errors.
     * ``Import`` / ``ImportFrom`` -- Starlark uses ``load()``; see
       ``_load_stmt_helper``.

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -292,6 +292,24 @@ class _GatedFeatureError(Exception):
         self.feature = feature
 
 
+def _reject_annotated_args(args: ast.arguments) -> None:
+    """Raise ``_GatedFeatureError`` if any parameter in ``args`` carries
+    a type annotation. Starlark's Parameter grammar has no annotation
+    production, so annotations on any category of parameter -- regular,
+    positional-only, keyword-only, ``*args``, or ``**kwargs`` -- are
+    rejected uniformly.
+    """
+    for arg in (
+        *args.posonlyargs,
+        *args.args,
+        *args.kwonlyargs,
+        *((args.vararg,) if args.vararg is not None else ()),
+        *((args.kwarg,) if args.kwarg is not None else ()),
+    ):
+        if arg.annotation is not None:
+            raise _GatedFeatureError(arg.annotation, "parameter type annotation")
+
+
 class GatedLanguageFeaturesPass(ast.NodeVisitor):
     """Reject Python syntax that has no Starlark analogue.
 
@@ -332,7 +350,15 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # gated constructs inside the function are still reported.
         if node.decorator_list:
             raise _GatedFeatureError(node.decorator_list[0], "decorator")
+        # Starlark's parameter grammar has no annotation syntax, and its
+        # function headers have no return-type annotation. Reject both.
+        if node.returns is not None:
+            raise _GatedFeatureError(node.returns, "return type annotation")
+        _reject_annotated_args(node.args)
         self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        raise _GatedFeatureError(node, "variable type annotation")
 
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -326,6 +326,14 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         raise _GatedFeatureError(node, "walrus operator (`:=`)")
 
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Decorators have no analogue in the Starlark ``DefStmt`` grammar.
+        # Reject them, but continue recursing into the body so that other
+        # gated constructs inside the function are still reported.
+        if node.decorator_list:
+            raise _GatedFeatureError(node.decorator_list[0], "decorator")
+        self.generic_visit(node)
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -384,6 +384,19 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # ``del`` statement.
         raise _GatedFeatureError(node, "`del` statement")
 
+    def visit_BinOp(self, node: ast.BinOp) -> None:
+        # ``@`` (matrix multiplication) is not in Starlark's binary
+        # operator list. Other binary operators are fine.
+        if isinstance(node.op, ast.MatMult):
+            raise _GatedFeatureError(node, "matrix-multiplication operator (`@`)")
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        # Same reasoning for the in-place form ``@=``.
+        if isinstance(node.op, ast.MatMult):
+            raise _GatedFeatureError(node, "matrix-multiplication assignment (`@=`)")
+        self.generic_visit(node)
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -374,6 +374,11 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # DictComp; set comprehensions have no equivalent.
         raise _GatedFeatureError(node, "set comprehension")
 
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        # Starlark has no generators and no generator-expression
+        # production in its grammar.
+        raise _GatedFeatureError(node, "generator expression")
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -360,6 +360,11 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         raise _GatedFeatureError(node, "variable type annotation")
 
+    def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
+        # Starlark's lexical grammar offers only plain string and bytes
+        # literals. Reject f-strings so that plugin sources stay portable.
+        raise _GatedFeatureError(node, "f-string")
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -365,6 +365,15 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # literals. Reject f-strings so that plugin sources stay portable.
         raise _GatedFeatureError(node, "f-string")
 
+    def visit_Set(self, node: ast.Set) -> None:
+        # Starlark has no set type and therefore no set-display syntax.
+        raise _GatedFeatureError(node, "set display")
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        # Starlark's comprehension grammar offers only ListComp and
+        # DictComp; set comprehensions have no equivalent.
+        raise _GatedFeatureError(node, "set comprehension")
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -331,6 +331,26 @@ def _find_slice_assign_target(target: ast.expr) -> ast.Subscript | None:
     return None
 
 
+def _find_starred_in_target(target: ast.expr) -> ast.Starred | None:
+    """Return the offending ``Starred`` node if ``target`` is, or
+    contains anywhere within a tuple/list unpacking spine, a starred
+    expression. Return ``None`` otherwise.
+
+    Starlark's ``LoopVariables`` and ``AssignStmt`` LHS grammars do not
+    permit ``*x`` unpacking; a starred target would have no portable
+    equivalent. Starred expressions on the *right-hand side* or inside
+    call arguments (``f(*args)``) are a separate grammatical position
+    and are not checked here.
+    """
+    if isinstance(target, ast.Starred):
+        return target
+    if isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            if (found := _find_starred_in_target(elt)) is not None:
+                return found
+    return None
+
+
 class GatedLanguageFeaturesPass(ast.NodeVisitor):
     """Reject Python syntax that has no Starlark analogue.
 
@@ -432,6 +452,9 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # Starlark forbids a slice expression on the LHS of an assignment.
         if (bad := _find_slice_assign_target(node.target)) is not None:
             raise _GatedFeatureError(bad, "slice as assignment target")
+        # Starlark does not permit ``*x`` unpacking in an assignment LHS.
+        if (starred := _find_starred_in_target(node.target)) is not None:
+            raise _GatedFeatureError(starred, "starred assignment target")
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:
@@ -439,6 +462,26 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         for target in node.targets:
             if (bad := _find_slice_assign_target(target)) is not None:
                 raise _GatedFeatureError(bad, "slice as assignment target")
+            if (starred := _find_starred_in_target(target)) is not None:
+                raise _GatedFeatureError(starred, "starred assignment target")
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        # Starlark's LoopVariables grammar permits no ``*x`` unpacking.
+        if (starred := _find_starred_in_target(node.target)) is not None:
+            raise _GatedFeatureError(starred, "starred loop variable")
+        self.generic_visit(node)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        for gen in node.generators:
+            if (starred := _find_starred_in_target(gen.target)) is not None:
+                raise _GatedFeatureError(starred, "starred loop variable")
+        self.generic_visit(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        for gen in node.generators:
+            if (starred := _find_starred_in_target(gen.target)) is not None:
+                raise _GatedFeatureError(starred, "starred loop variable")
         self.generic_visit(node)
 
     def visit_Compare(self, node: ast.Compare) -> None:

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -509,6 +509,14 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # Compare node) accordingly.
         if len(node.ops) > 1:
             raise _GatedFeatureError(node, "chained comparison")
+        # Starlark's comparison operator list is ``==``, ``!=``, ``<``,
+        # ``>``, ``<=``, ``>=``, ``in`` and ``not in``; there are no
+        # identity operators.
+        for op in node.ops:
+            if isinstance(op, ast.Is):
+                raise _GatedFeatureError(node, "`is` operator")
+            if isinstance(op, ast.IsNot):
+                raise _GatedFeatureError(node, "`is not` operator")
         self.generic_visit(node)
 
     def visit_Raise(self, node: ast.Raise) -> None:

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -379,6 +379,11 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # production in its grammar.
         raise _GatedFeatureError(node, "generator expression")
 
+    def visit_Delete(self, node: ast.Delete) -> None:
+        # Starlark's spec explicitly states that it does not have a
+        # ``del`` statement.
+        raise _GatedFeatureError(node, "`del` statement")
+
     def visit_Raise(self, node: ast.Raise) -> None:
         raise _GatedFeatureError(node, "`raise` statement")
 

--- a/ruyi/pluginhost/unsandboxed.py
+++ b/ruyi/pluginhost/unsandboxed.py
@@ -390,6 +390,13 @@ class GatedLanguageFeaturesPass(ast.NodeVisitor):
         # ``del`` statement.
         raise _GatedFeatureError(node, "`del` statement")
 
+    def visit_While(self, node: ast.While) -> None:
+        # Starlark's Statement grammar only has DefStmt, IfStmt, ForStmt
+        # and SimpleStmt; ``while`` is listed among the reserved-but-
+        # unused keywords. Rejecting it here also keeps plugin loops
+        # bounded in the same way Starlark intends.
+        raise _GatedFeatureError(node, "`while` loop")
+
     def visit_BinOp(self, node: ast.BinOp) -> None:
         # ``@`` (matrix multiplication) is not in Starlark's binary
         # operator list. Other binary operators are fine.

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -56,6 +56,7 @@ def test_plain_module_passes() -> None:
         ("x = [1]\ndel x\n", "del"),
         ("x = a @ b\n", "matrix-multiplication operator"),
         ("a @= b\n", "matrix-multiplication assignment"),
+        ("ok = 0 <= i < n\n", "chained comparison"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -58,6 +58,7 @@ def test_plain_module_passes() -> None:
         ("a @= b\n", "matrix-multiplication assignment"),
         ("ok = 0 <= i < n\n", "chained comparison"),
         ("def f(a, /, b):\n    return a + b\n", "positional-only parameter"),
+        ("def f():\n    while True:\n        pass\n", "while"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -18,6 +18,13 @@ def test_plain_module_passes() -> None:
     )
 
 
+def test_slice_in_value_position_passes() -> None:
+    # Slicing on the RHS of an assignment, and as a subexpression on the
+    # LHS but not as the outermost Subscript's slice, is legal Starlark.
+    _lint("a = xs[1:3]\n")
+    _lint("xs[ys[1:3]] = 0\n")
+
+
 @pytest.mark.parametrize(
     ("src", "expected_feature"),
     [
@@ -59,6 +66,8 @@ def test_plain_module_passes() -> None:
         ("ok = 0 <= i < n\n", "chained comparison"),
         ("def f(a, /, b):\n    return a + b\n", "positional-only parameter"),
         ("def f():\n    while True:\n        pass\n", "while"),
+        ("xs[1:3] = [0]\n", "slice as assignment target"),
+        ("xs[1:3] += [0]\n", "slice as assignment target"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -46,6 +46,9 @@ def test_plain_module_passes() -> None:
         ("class C:\n    pass\n", "class"),
         ("async def g():\n    pass\n", "async def"),
         ("@staticmethod\ndef f():\n    pass\n", "decorator"),
+        ("x: int = 1\n", "variable type annotation"),
+        ("def f() -> int:\n    return 1\n", "return type annotation"),
+        ("def f(x: int):\n    return x\n", "parameter type annotation"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -54,6 +54,8 @@ def test_plain_module_passes() -> None:
         ("x = {i for i in range(3)}\n", "set comprehension"),
         ("x = sum(i for i in range(3))\n", "generator expression"),
         ("x = [1]\ndel x\n", "del"),
+        ("x = a @ b\n", "matrix-multiplication operator"),
+        ("a @= b\n", "matrix-multiplication assignment"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -1,0 +1,60 @@
+import ast
+
+import pytest
+
+from ruyi.pluginhost.unsandboxed import lint_module
+
+
+def _lint(src: str) -> None:
+    lint_module(ast.parse(src))
+
+
+def test_plain_module_passes() -> None:
+    _lint(
+        "x = 1\n"
+        "def f(a, b):\n"
+        "    return a + b\n"
+        "y = [f(i, 1) for i in range(10)]\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("src", "expected_feature"),
+    [
+        ("y = (x := 1)\n", "walrus"),
+        ("raise ValueError('x')\n", "raise"),
+        ("assert True\n", "assert"),
+        ("import os\n", "import"),
+        ("from os import path\n", "from"),
+        ("try:\n    pass\nexcept Exception:\n    pass\n", "try"),
+        ("with open('x') as f:\n    pass\n", "with"),
+        (
+            "match x:\n    case 1:\n        pass\n    case _:\n        pass\n",
+            "match",
+        ),
+        ("def g():\n    yield 1\n", "yield"),
+        ("def g():\n    yield from [1]\n", "yield from"),
+        ("def g():\n    global x\n", "global"),
+        (
+            "def outer():\n"
+            "    x = 1\n"
+            "    def inner():\n"
+            "        nonlocal x\n"
+            "    return inner\n",
+            "nonlocal",
+        ),
+        ("class C:\n    pass\n", "class"),
+        ("async def g():\n    pass\n", "async def"),
+        # `await`, `async for`, `async with` can only occur syntactically
+        # inside an `async def`, so they are shadowed by the `async def`
+        # rejection above; they have their own ``visit_*`` overrides anyway
+        # for defence in depth.
+    ],
+)
+def test_gated_feature_is_rejected(src: str, expected_feature: str) -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        _lint(src)
+    msg = str(excinfo.value)
+    assert "is not allowed in plugin code" in msg
+    assert expected_feature in msg
+    assert "line " in msg

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -71,6 +71,8 @@ def test_starred_in_call_and_rhs_passes() -> None:
         ("x = a @ b\n", "matrix-multiplication operator"),
         ("a @= b\n", "matrix-multiplication assignment"),
         ("ok = 0 <= i < n\n", "chained comparison"),
+        ("ok = a is b\n", "`is` operator"),
+        ("ok = a is not b\n", "`is not` operator"),
         ("def f(a, /, b):\n    return a + b\n", "positional-only parameter"),
         ("def f():\n    while True:\n        pass\n", "while"),
         ("xs[1:3] = [0]\n", "slice as assignment target"),

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -52,6 +52,7 @@ def test_plain_module_passes() -> None:
         ("x = f'hello {name}'\n", "f-string"),
         ("x = {1, 2, 3}\n", "set display"),
         ("x = {i for i in range(3)}\n", "set comprehension"),
+        ("x = sum(i for i in range(3))\n", "generator expression"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -50,6 +50,8 @@ def test_plain_module_passes() -> None:
         ("def f() -> int:\n    return 1\n", "return type annotation"),
         ("def f(x: int):\n    return x\n", "parameter type annotation"),
         ("x = f'hello {name}'\n", "f-string"),
+        ("x = {1, 2, 3}\n", "set display"),
+        ("x = {i for i in range(3)}\n", "set comprehension"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -49,6 +49,7 @@ def test_plain_module_passes() -> None:
         ("x: int = 1\n", "variable type annotation"),
         ("def f() -> int:\n    return 1\n", "return type annotation"),
         ("def f(x: int):\n    return x\n", "parameter type annotation"),
+        ("x = f'hello {name}'\n", "f-string"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -77,9 +77,12 @@ def test_starred_in_call_and_rhs_passes() -> None:
         ("def f():\n    while True:\n        pass\n", "while"),
         ("xs[1:3] = [0]\n", "slice as assignment target"),
         ("xs[1:3] += [0]\n", "slice as assignment target"),
+        ("(xs[1:3], y[0]) = (0, 1)\n", "slice as assignment target"),
+        ("[xs[1:3], y[0]] = [0, 1]\n", "slice as assignment target"),
         ("a, *rest = xs\n", "starred assignment target"),
         ("for *a, b in xs:\n    pass\n", "starred loop variable"),
         ("y = [x for *a, b in xs]\n", "starred loop variable"),
+        ("y = {k: v for *a, (k, v) in xs}\n", "starred loop variable"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway
@@ -93,3 +96,27 @@ def test_gated_feature_is_rejected(src: str, expected_feature: str) -> None:
     assert "is not allowed in plugin code" in msg
     assert expected_feature in msg
     assert "line " in msg
+
+
+@pytest.mark.parametrize(
+    ("src", "expected_line", "expected_feature"),
+    [
+        # Walrus on the third line of the module.
+        ("x = 1\ny = 2\nz = (w := 3)\n", 3, "walrus"),
+        # ``del`` on line 2.
+        ("x = [1]\ndel x\n", 2, "del"),
+        # Decorator declared on line 1, its function header on line 2;
+        # the gate reports the decorator's own line.
+        ("@staticmethod\ndef f():\n    return 1\n", 1, "decorator"),
+        # Nested gated construct: the inner ``while`` is on line 3.
+        ("def f():\n    x = 1\n    while x:\n        x = 0\n", 3, "while"),
+    ],
+)
+def test_gated_feature_reports_correct_line(
+    src: str, expected_line: int, expected_feature: str
+) -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        _lint(src)
+    msg = str(excinfo.value)
+    assert f"line {expected_line}:" in msg
+    assert expected_feature in msg

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -57,6 +57,7 @@ def test_plain_module_passes() -> None:
         ("x = a @ b\n", "matrix-multiplication operator"),
         ("a @= b\n", "matrix-multiplication assignment"),
         ("ok = 0 <= i < n\n", "chained comparison"),
+        ("def f(a, /, b):\n    return a + b\n", "positional-only parameter"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -53,6 +53,7 @@ def test_plain_module_passes() -> None:
         ("x = {1, 2, 3}\n", "set display"),
         ("x = {i for i in range(3)}\n", "set comprehension"),
         ("x = sum(i for i in range(3))\n", "generator expression"),
+        ("x = [1]\ndel x\n", "del"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -45,6 +45,7 @@ def test_plain_module_passes() -> None:
         ),
         ("class C:\n    pass\n", "class"),
         ("async def g():\n    pass\n", "async def"),
+        ("@staticmethod\ndef f():\n    pass\n", "decorator"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway

--- a/tests/pluginhost/test_lint_module.py
+++ b/tests/pluginhost/test_lint_module.py
@@ -25,6 +25,13 @@ def test_slice_in_value_position_passes() -> None:
     _lint("xs[ys[1:3]] = 0\n")
 
 
+def test_starred_in_call_and_rhs_passes() -> None:
+    # ``*args`` / ``**kwargs`` in call arguments and starred elements on
+    # the RHS of an assignment are valid Starlark and must not be gated.
+    _lint("f(*args, **kwargs)\n")
+    _lint("xs = [*a, *b]\n")
+
+
 @pytest.mark.parametrize(
     ("src", "expected_feature"),
     [
@@ -68,6 +75,9 @@ def test_slice_in_value_position_passes() -> None:
         ("def f():\n    while True:\n        pass\n", "while"),
         ("xs[1:3] = [0]\n", "slice as assignment target"),
         ("xs[1:3] += [0]\n", "slice as assignment target"),
+        ("a, *rest = xs\n", "starred assignment target"),
+        ("for *a, b in xs:\n    pass\n", "starred loop variable"),
+        ("y = [x for *a, b in xs]\n", "starred loop variable"),
         # `await`, `async for`, `async with` can only occur syntactically
         # inside an `async def`, so they are shadowed by the `async def`
         # rejection above; they have their own ``visit_*`` overrides anyway


### PR DESCRIPTION
Make accepted plugin code more conforming to the Starlark subset, and explicitly document why an unsandboxed approach was chosen since #214. Also see #444 for future references.

## Summary by Sourcery

Tighten the unsandboxed plugin host’s accepted Python subset for better alignment with Starlark and document the non-sandbox threat model, while adding tests to validate gated language features and diagnostics.

Enhancements:
- Document the rationale, threat model, and Starlark-portability goals of the unsandboxed plugin host module.
- Constrain exposed Python builtins and load semantics to remain compatible with a future Starlark-based backend.
- Refine the AST-based linting pass to explicitly reject Python constructs without Starlark analogues and surface clearer error messages for gated features.

Tests:
- Add unit tests covering allowed and rejected language constructs in plugin code, verifying that linting fails with informative diagnostics for each gated feature.