### PR TITLE
[repo format change] rename "manifests" directory to "packages"

### DIFF
--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -144,7 +144,7 @@ urls = ["https://example.com/dist/"]
 其中 `[repo].id` 应与用户配置中 `[[repos]]` 条目的 `id` 一致。如果两者不一致，
 `ruyi update` 会发出警告。
 
-2. 一个 `manifests/` 目录，内部包含符合标准[软件源结构定义](repo-structure.md)的软件包定义。
+2. 一个 `packages/` 目录，内部包含符合标准[软件源结构定义](repo-structure.md)的软件包定义。
 
 ## 迁移说明
 

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -14,14 +14,14 @@ Ruyi 软件源承担两种职能，从而也由两部分构成：
 ```plain
 packages-index
 ├── config.toml
-├── manifests
-│   └── toolchain
-│       └── plct
-│           └── 0.20231026.0.toml
 ├── messages.toml
 ├── news
 │   ├── YYYY-MM-DD-news-title.en_US.md
 │   └── YYYY-MM-DD-news-title.zh_CN.md
+├── packages
+│   └── toolchain
+│       └── plct
+│           └── 0.20231026.0.toml
 ├── plugins
 │   ├── ruyi-cmd-foo-bar
 │   │   └── mod.star
@@ -135,7 +135,7 @@ zh_CN = "一条 Jinja 格式的文案模板"
 en_US = "Another message"
 ```
 
-### `manifests`
+### `packages`
 
 此目录内含 0 或多个子目录，子目录对应软件包类别（category），目录名为类别名。
 

--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -517,13 +517,23 @@ class MetadataRepo(ProvidesPackageManifests):
         if ensure_repo:
             self.ensure_git_repo()
 
-        manifests_dir = os.path.join(self.root, "manifests")
-        try:
-            for f in os.scandir(manifests_dir):
+        # Try the name "packages" first, because it's possible that some
+        # non-manifest things will arrive in the package directories in the
+        # future. Keep probing the old "manifests" name until 0.51.0.
+        #
+        # TODO: remove the "manifests" alias after 0.50.0 branch is cut.
+        for pkg_dir_name in ("packages", "manifests"):
+            manifests_dir = os.path.join(self.root, pkg_dir_name)
+            try:
+                manifests_dir_iter = os.scandir(manifests_dir)
+            except FileNotFoundError:
+                continue
+
+            for f in manifests_dir_iter:
                 if not f.is_dir():
                     continue
                 yield from self._iter_pkg_manifests_from_category(f.path)
-        except FileNotFoundError:
+            # Only process the first matched directory
             return
 
     def _iter_pkg_manifests_from_category(

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -248,7 +248,7 @@ class IntegrationTestHarness:
         version: str,
         manifest_toml: str,
     ) -> pathlib.Path:
-        pkg_dir = self.repo_root / "manifests" / category / name
+        pkg_dir = self.repo_root / "packages" / category / name
         pkg_dir.mkdir(parents=True, exist_ok=True)
         manifest_path = pkg_dir / f"{version}.toml"
         manifest_path.write_text(manifest_toml, encoding="utf-8")
@@ -285,7 +285,7 @@ size = 0
 sha256 = "{sha_stub}"
 """
 
-    manifest_dir = repo_root / "manifests" / "dev-tools" / "sample-cli"
+    manifest_dir = repo_root / "packages" / "dev-tools" / "sample-cli"
     manifest_dir.mkdir(parents=True, exist_ok=True)
     (manifest_dir / "1.0.0.toml").write_text(manifest_text + "\n", encoding="utf-8")
 

--- a/tests/integration/test_multi_repo.py
+++ b/tests/integration/test_multi_repo.py
@@ -56,7 +56,7 @@ def _add_manifest(
     desc: str = "test package",
 ) -> None:
     """Write a minimal package manifest into a repo directory."""
-    pkg_dir = repo_root / "manifests" / category / name
+    pkg_dir = repo_root / "packages" / category / name
     pkg_dir.mkdir(parents=True, exist_ok=True)
     manifest = f"""\
 format = "v1"

--- a/tests/ruyipkg/test_composite_repo.py
+++ b/tests/ruyipkg/test_composite_repo.py
@@ -44,7 +44,7 @@ def _write_manifest(
     desc: str = "test package",
 ) -> None:
     """Write a minimal package manifest TOML file into a repo tree."""
-    pkg_dir = root / "manifests" / category / name
+    pkg_dir = root / "packages" / category / name
     pkg_dir.mkdir(parents=True, exist_ok=True)
 
     lines = [


### PR DESCRIPTION
Because the package directory could house some more metadata not restricted to just manifests in the future.

Technically the compatibility can be dropped as well, because the official packages-index repo has adopted a compat symlink (manifests -> packages) since the RuyiSDK 0.46 release (0.46.0) in Feb 2026. But let's keep it for 3 releases so as to make the Git timeline in this repo consistent with our deprecation policy.

## Summary by Sourcery

Rename the repository package directory from "manifests" to "packages" while maintaining backward compatibility when iterating manifests.

Enhancements:
- Allow manifest iteration to fall back to the legacy "manifests" directory while preferring the new "packages" directory name.

Documentation:
- Update repository structure and multi-repo documentation to describe the new "packages" directory instead of "manifests".

Tests:
- Adjust test fixtures and integration tests to use the new "packages" directory layout for package manifests.