### PR TITLE
ci: link to the existing user home directory more robustly

### DIFF
--- a/scripts/dist-image/prepare-distro.sh
+++ b/scripts/dist-image/prepare-distro.sh
@@ -60,7 +60,7 @@ add_builder_user() {
     _getent_result="$(getent passwd "$BUILDER_UID")"
 
     if [[ -n $_getent_result ]]; then
-        ln -s "/home/${_getent_result%%:*}" /home/b
+        ln -s "$(cut -f6 -d: <<<"$_getent_result")" /home/b
     else
         groupadd -g "$BUILDER_GID" b
         useradd -d /home/b -m -g "$BUILDER_GID" -u "$BUILDER_UID" -s /bin/bash b


### PR DESCRIPTION
The agent was right this time.

See: https://github.com/ruyisdk/ruyi/pull/449#discussion_r3130479183

## Summary by Sourcery

Bug Fixes:
- Fix symlink creation for the builder user's home directory to reliably use the path from the passwd entry.