### PR TITLE
Fix more unexpected interactions between shell auto-completion and OOBE/telemetry

### DIFF
--- a/ruyi/cli/main.py
+++ b/ruyi/cli/main.py
@@ -6,7 +6,10 @@ from typing import Final, TYPE_CHECKING
 from ..config import GlobalConfig
 from ..i18n import _
 from ..telemetry.scope import TelemetryScope
-from ..utils.global_mode import GlobalModeProvider
+from ..utils.global_mode import (
+    GlobalModeProvider,
+    is_cli_completion_script_requested,
+)
 from ..version import RUYI_SEMVER
 from . import RUYI_ENTRYPOINT_NAME
 from .oobe import OOBE
@@ -33,11 +36,12 @@ def should_prompt_for_renaming(argv0: str) -> bool:
 
 def main(gm: GlobalModeProvider, gc: GlobalConfig, argv: list[str]) -> int:
     logger = gc.logger
+    is_completion_script_invocation = is_cli_completion_script_requested(argv)
 
-    # do not init telemetry or OOBE on CLI auto-completion invocations, because
+    # do not init telemetry or OOBE on shell completion invocations, because
     # our output isn't meant for humans in that case, and a "real" invocation
     # will likely follow shortly after
-    if not gm.is_cli_autocomplete:
+    if not gm.is_cli_autocomplete and not is_completion_script_invocation:
         oobe = OOBE(gc)
 
         tm = gc.telemetry
@@ -130,11 +134,9 @@ def main(gm: GlobalModeProvider, gc: GlobalConfig, argv: list[str]) -> int:
 
     # Special-case the `--output-completion-script` argument; treat it as if
     # "ruyi completion-script" were called.
-    try:
-        if args.completion_script:
-            telemetry_key = "completion-script"
-    except AttributeError:
-        pass
+    completion_script: str | None = getattr(args, "completion_script", None)
+    if is_completion_script_invocation and completion_script is not None:
+        return func(gc, args)
 
     tm = gc.telemetry
     tm.print_telemetry_notice()

--- a/ruyi/ruyipkg/cli_completion.py
+++ b/ruyi/ruyipkg/cli_completion.py
@@ -20,33 +20,29 @@ def package_completer_builder(
     cfg: "GlobalConfig",
     filters: list[Callable[[str], bool]] | None = None,
 ) -> "DynamicCompleter":
-    # Lazy import to avoid circular dependency
-    from ..ruyipkg.augmented_pkg import (
-        AugmentedPkg,
-    )  # pylint: disable=import-outside-toplevel
-    from ..ruyipkg.list_filter import (
-        ListFilter,
-    )  # pylint: disable=import-outside-toplevel
-
-    all_pkgs = list(
-        AugmentedPkg.yield_from_repo(
-            cfg,
-            cfg.repo,
-            ListFilter(),
-        )
-    )
-    if filters is not None:
-        all_pkgs = [
-            pkg
-            for pkg in all_pkgs
-            if pkg.name is not None and all(f(pkg.name) for f in filters)
-        ]
+    pkg_names: list[str] | None = None
 
     def f(prefix: str, parsed_args: object, **kwargs: Any) -> list[str]:
-        return [
-            pkg.name
-            for pkg in all_pkgs
-            if pkg.name is not None and pkg.name.startswith(prefix)
-        ]
+        nonlocal pkg_names
+
+        if pkg_names is None:
+            # Lazy import to avoid circular dependency, and lazy repo access so
+            # parser construction for unrelated completions does not sync repos.
+            from ..ruyipkg.augmented_pkg import (
+                AugmentedPkg,
+            )  # pylint: disable=import-outside-toplevel
+            from ..ruyipkg.list_filter import (
+                ListFilter,
+            )  # pylint: disable=import-outside-toplevel
+
+            pkg_names = []
+            for pkg in AugmentedPkg.yield_from_repo(cfg, cfg.repo, ListFilter()):
+                if pkg.name is None:
+                    continue
+                if filters is not None and not all(fn(pkg.name) for fn in filters):
+                    continue
+                pkg_names.append(pkg.name)
+
+        return [name for name in pkg_names if name.startswith(prefix)]
 
     return f

--- a/ruyi/utils/global_mode.py
+++ b/ruyi/utils/global_mode.py
@@ -1,6 +1,6 @@
 import abc
 import os
-from typing import Final, Mapping, Protocol, runtime_checkable
+from typing import Final, Mapping, Protocol, Sequence, runtime_checkable
 
 import ruyi
 
@@ -128,21 +128,19 @@ def _guess_porcelain_from_argv(argv: list[str]) -> bool:
     return len(argv) > 1 and argv[1] == "--porcelain"
 
 
-def _probe_cli_autocomplete(env: Mapping[str, str], argv: list[str]) -> bool:
-    """
-    Probe if the current invocation is related to shell completion based on
-    the arguments passed, without requiring the ``argparse`` machinery to be
-    completely initialized, and the environment.
-    """
-
-    # If `--output-completion-script` is present anywhere in the arguments,
-    # then this is related to shell completion even if _ARGCOMPLETE is not yet
-    # set (which is only set for invocations after the shell finished sourcing
-    # the completion script).
+def is_cli_completion_script_requested(argv: Sequence[str]) -> bool:
     for arg in argv:
         if arg.startswith("--output-completion-script"):
             return True
+    return False
 
+
+def _probe_cli_autocomplete(env: Mapping[str, str]) -> bool:
+    """
+    Probe if the current invocation is an argcomplete subprocess based on the
+    environment, without requiring the ``argparse`` machinery to be completely
+    initialized.
+    """
     return "_ARGCOMPLETE" in env
 
 
@@ -168,7 +166,7 @@ class EnvGlobalModeProvider(GlobalModeProvider):
 
         # We have to lift this piece of implementation detail out of argcomplete,
         # as the argcomplete import is very costly in terms of startup time.
-        self._is_cli_autocomplete = _probe_cli_autocomplete(env, argv)
+        self._is_cli_autocomplete = _probe_cli_autocomplete(env)
 
         self._venv_root = env.get(ENV_VENV_ROOT_KEY)
 

--- a/ruyi/utils/global_mode.py
+++ b/ruyi/utils/global_mode.py
@@ -130,7 +130,7 @@ def _guess_porcelain_from_argv(argv: list[str]) -> bool:
 
 def is_cli_completion_script_requested(argv: Sequence[str]) -> bool:
     for arg in argv:
-        if arg.startswith("--output-completion-script"):
+        if arg.split("=", 1)[0] == "--output-completion-script":
             return True
     return False
 

--- a/tests/integration/test_cli_basic.py
+++ b/tests/integration/test_cli_basic.py
@@ -42,6 +42,23 @@ def test_output_completion_script_does_not_access_repo_or_telemetry(
     assert not (telemetry_root / "telemetry" / "minimal-installation-marker").exists()
 
 
+def test_autocomplete_parser_build_does_not_access_package_repo(
+    ruyi_cli_runner: IntegrationTestHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ruyi.cli import builtin_commands
+    from ruyi.cli.cmd import RootCommand
+    from ruyi.ruyipkg.repo import MetadataRepo
+
+    del builtin_commands
+
+    ctx = ruyi_cli_runner.make_command_context()
+    ctx.gm._is_cli_autocomplete = True  # pylint: disable=protected-access
+    monkeypatch.setattr(MetadataRepo, "ensure_git_repo", _fail_on_repo_access)
+
+    RootCommand.build_argparse(ctx.gc)
+
+
 def test_cli_list_with_mock_repo(ruyi_cli_runner: IntegrationTestHarness) -> None:
     result = ruyi_cli_runner("list", "--name-contains", "sample-cli")
 

--- a/tests/integration/test_cli_basic.py
+++ b/tests/integration/test_cli_basic.py
@@ -1,10 +1,15 @@
+import pathlib
+from tests.fixtures import IntegrationTestHarness
+
 import pytest
 
 from ruyi.ruyipkg.distfile import Distfile
-from tests.fixtures import IntegrationTestHarness
-
 
 SHA_STUB = "0" * 64
+
+
+def _fail_on_repo_access(self: object) -> None:
+    raise AssertionError("completion setup must not access the package repo")
 
 
 def test_cli_version(ruyi_cli_runner: IntegrationTestHarness) -> None:
@@ -16,6 +21,25 @@ def test_cli_version(ruyi_cli_runner: IntegrationTestHarness) -> None:
         assert result.exit_code == 0
         assert "Ruyi" in result.stdout
         assert "fatal error" not in result.stderr.lower()
+
+
+def test_output_completion_script_does_not_access_repo_or_telemetry(
+    ruyi_cli_runner: IntegrationTestHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ruyi.ruyipkg.repo import MetadataRepo
+
+    monkeypatch.setattr(MetadataRepo, "ensure_git_repo", _fail_on_repo_access)
+
+    result = ruyi_cli_runner("--output-completion-script=bash")
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("#compdef ruyi\n")
+    assert "package repository" not in result.stderr
+
+    telemetry_root = pathlib.Path(ruyi_cli_runner._env["XDG_STATE_HOME"]) / "ruyi"
+    assert not (telemetry_root / "telemetry" / "installation.json").exists()
+    assert not (telemetry_root / "telemetry" / "minimal-installation-marker").exists()
 
 
 def test_cli_list_with_mock_repo(ruyi_cli_runner: IntegrationTestHarness) -> None:

--- a/tests/utils/test_global_mode.py
+++ b/tests/utils/test_global_mode.py
@@ -1,0 +1,15 @@
+from ruyi.utils.global_mode import is_cli_completion_script_requested
+
+
+def test_is_cli_completion_script_requested_matches_only_exact_option() -> None:
+    assert is_cli_completion_script_requested(["ruyi", "--output-completion-script"])
+    assert is_cli_completion_script_requested(
+        ["ruyi", "--output-completion-script=bash"]
+    )
+
+    assert not is_cli_completion_script_requested(
+        ["ruyi", "--output-completion-script-foo"]
+    )
+    assert not is_cli_completion_script_requested(
+        ["ruyi", "--output-completion-script-foo=bash"]
+    )


### PR DESCRIPTION
## Summary by Sourcery

Ensure shell completion script generation and autocomplete parser construction do not trigger repository sync, OOBE, or telemetry initialization, and adjust completion detection logic accordingly.

Bug Fixes:
- Avoid accessing the package repository when building CLI argument parsers for shell autocomplete.
- Prevent telemetry and OOBE initialization during shell completion script generation and argcomplete subprocesses.
- Fix package name completion to lazily read and cache package names only when completion is actually invoked, respecting optional filters.

Tests:
- Add integration tests verifying that outputting the completion script and building the autocomplete parser do not access the package repository or create telemetry files.