### PR TITLE
Do not trigger OOBE or telemetry for simple version queries

### DIFF
--- a/ruyi/cli/main.py
+++ b/ruyi/cli/main.py
@@ -20,7 +20,8 @@ ALLOWED_RUYI_ENTRYPOINT_NAMES: Final = (
     f"{RUYI_ENTRYPOINT_NAME}.bin",  # Nuitka one-file program cache
     "__main__.py",
 )
-VERSION_QUERY_ARGS: Final = frozenset(("-V", "--version", "version"))
+VERSION_QUERY_FLAGS: Final = frozenset(("-V", "--version"))
+VERSION_QUERY_SUBCOMMAND: Final = "version"
 
 
 def is_called_as_ruyi(argv0: str) -> bool:
@@ -36,10 +37,17 @@ def should_prompt_for_renaming(argv0: str) -> bool:
 
 
 def is_version_query(argv: list[str]) -> bool:
+    # Scan flags broadly for issue #453, while only accepting the subcommand
+    # spelling in command position so positional values named "version" do not
+    # suppress OOBE/telemetry for unrelated commands.
+    for arg in argv[1:]:
+        if arg in VERSION_QUERY_FLAGS:
+            return True
+
     for arg in argv[1:]:
         if arg == "--porcelain":
             continue
-        return arg in VERSION_QUERY_ARGS
+        return arg == VERSION_QUERY_SUBCOMMAND
 
     return False
 

--- a/ruyi/cli/main.py
+++ b/ruyi/cli/main.py
@@ -20,6 +20,7 @@ ALLOWED_RUYI_ENTRYPOINT_NAMES: Final = (
     f"{RUYI_ENTRYPOINT_NAME}.bin",  # Nuitka one-file program cache
     "__main__.py",
 )
+VERSION_QUERY_ARGS: Final = frozenset(("-V", "--version", "version"))
 
 
 def is_called_as_ruyi(argv0: str) -> bool:
@@ -34,14 +35,32 @@ def should_prompt_for_renaming(argv0: str) -> bool:
     return os.path.basename(argv0).lower().startswith(likely_artifact_name_prefix)
 
 
+def is_version_query(argv: list[str]) -> bool:
+    for arg in argv[1:]:
+        if arg == "--porcelain":
+            continue
+        return arg in VERSION_QUERY_ARGS
+
+    return False
+
+
 def main(gm: GlobalModeProvider, gc: GlobalConfig, argv: list[str]) -> int:
     logger = gc.logger
     is_completion_script_invocation = is_cli_completion_script_requested(argv)
+    is_ruyi_invocation = is_called_as_ruyi(gm.argv0)
+    # Version queries must be side-effect-free: issue #453 showed that OOBE
+    # could otherwise prompt before printing the version and consume first-run
+    # telemetry state.
+    skip_telemetry = is_ruyi_invocation and is_version_query(argv)
 
     # do not init telemetry or OOBE on shell completion invocations, because
     # our output isn't meant for humans in that case, and a "real" invocation
     # will likely follow shortly after
-    if not gm.is_cli_autocomplete and not is_completion_script_invocation:
+    if (
+        not gm.is_cli_autocomplete
+        and not is_completion_script_invocation
+        and not skip_telemetry
+    ):
         oobe = OOBE(gc)
 
         tm = gc.telemetry
@@ -52,7 +71,7 @@ def main(gm: GlobalModeProvider, gc: GlobalConfig, argv: list[str]) -> int:
 
         oobe.maybe_prompt()
 
-    if not is_called_as_ruyi(gm.argv0):
+    if not is_ruyi_invocation:
         if should_prompt_for_renaming(gm.argv0):
             logger.F(
                 _(
@@ -138,20 +157,21 @@ def main(gm: GlobalModeProvider, gc: GlobalConfig, argv: list[str]) -> int:
     if is_completion_script_invocation and completion_script is not None:
         return func(gc, args)
 
-    tm = gc.telemetry
-    tm.print_telemetry_notice()
+    if not skip_telemetry:
+        tm = gc.telemetry
+        tm.print_telemetry_notice()
 
-    # Do not record `ruyi telemetry --cron-upload` invocations.
-    skip_recording_invocation = telemetry_key == "telemetry" and getattr(
-        args,
-        "cron_upload",
-        False,
-    )
-    if not skip_recording_invocation:
-        tm.record(
-            TelemetryScope(None),
-            "cli:invocation-v1",
-            key=telemetry_key,
+        # Do not record `ruyi telemetry --cron-upload` invocations.
+        skip_recording_invocation = telemetry_key == "telemetry" and getattr(
+            args,
+            "cron_upload",
+            False,
         )
+        if not skip_recording_invocation:
+            tm.record(
+                TelemetryScope(None),
+                "cli:invocation-v1",
+                key=telemetry_key,
+            )
 
     return func(gc, args)

--- a/tests/integration/test_cli_basic.py
+++ b/tests/integration/test_cli_basic.py
@@ -5,7 +5,7 @@ from tests.fixtures import IntegrationTestHarness
 
 import pytest
 
-from ruyi.cli.main import main as ruyi_main
+from ruyi.cli.main import is_version_query, main as ruyi_main
 from ruyi.log import RuyiConsoleLogger
 from ruyi.ruyipkg.distfile import Distfile
 
@@ -19,6 +19,18 @@ class _TTYStringIO(io.StringIO):
 
 def _fail_on_repo_access(self: object) -> None:
     raise AssertionError("completion setup must not access the package repo")
+
+
+def test_cli_version_query_detection() -> None:
+    assert is_version_query(["ruyi", "--version"])
+    assert is_version_query(["ruyi", "-V"])
+    assert is_version_query(["ruyi", "--porcelain", "--version"])
+    assert is_version_query(["ruyi", "--config", "foo", "--version"])
+    assert is_version_query(["ruyi", "version"])
+    assert is_version_query(["ruyi", "--porcelain", "version"])
+    assert not is_version_query(["ruyi"])
+    assert not is_version_query(["ruyi", "list"])
+    assert not is_version_query(["ruyi", "list", "version"])
 
 
 def test_cli_version(ruyi_cli_runner: IntegrationTestHarness) -> None:

--- a/tests/integration/test_cli_basic.py
+++ b/tests/integration/test_cli_basic.py
@@ -1,11 +1,20 @@
+import io
 import pathlib
+import sys
 from tests.fixtures import IntegrationTestHarness
 
 import pytest
 
+from ruyi.cli.main import main as ruyi_main
+from ruyi.log import RuyiConsoleLogger
 from ruyi.ruyipkg.distfile import Distfile
 
 SHA_STUB = "0" * 64
+
+
+class _TTYStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
 
 
 def _fail_on_repo_access(self: object) -> None:
@@ -57,6 +66,34 @@ def test_autocomplete_parser_build_does_not_access_package_repo(
     monkeypatch.setattr(MetadataRepo, "ensure_git_repo", _fail_on_repo_access)
 
     RootCommand.build_argparse(ctx.gc)
+
+
+def test_cli_version_skips_first_run_oobe(
+    ruyi_cli_runner: IntegrationTestHarness,
+    monkeypatch: "pytest.MonkeyPatch",
+) -> None:
+    for argv in [
+        ("--version",),
+        ("version",),
+    ]:
+        ctx = ruyi_cli_runner.make_command_context(*argv)
+        stdout = _TTYStringIO()
+        stderr = _TTYStringIO()
+
+        ctx.gc.logger = RuyiConsoleLogger(ctx.gm, stdout=stdout, stderr=stderr)
+        monkeypatch.setattr(sys, "stdin", _TTYStringIO())
+        monkeypatch.setattr(sys, "stdout", stdout)
+        monkeypatch.setattr(sys, "stderr", stderr)
+
+        exit_code = ruyi_main(ctx.gm, ctx.gc, ctx.argv)
+
+        assert exit_code == 0
+        assert "Ruyi" in stdout.getvalue()
+        assert "Welcome to RuyiSDK" not in stderr.getvalue()
+
+        telemetry_root = pathlib.Path(ctx.gc.telemetry_root)
+        assert not (telemetry_root / "installation.json").exists()
+        assert not (telemetry_root / "minimal-installation-marker").exists()
 
 
 def test_cli_list_with_mock_repo(ruyi_cli_runner: IntegrationTestHarness) -> None:


### PR DESCRIPTION
Version output is often used by scripts and should not trigger first-run setup. Issue #453 showed that the OOBE prompt could appear before the version text and consume telemetry first-run state, so bypass OOBE and invocation telemetry for ruyi's own version spellings.

Muxed tool invocations are still left to their own command handling, so this only touches the `ruyi`-proper.

Fixes: #453

## Summary by Sourcery

Skip first-run OOBE and telemetry side effects when the ruyi CLI is invoked only for version queries, and add tests to verify this behavior.

New Features:
- Treat simple version queries as side-effect-free invocations that bypass OOBE and telemetry recording.

Bug Fixes:
- Prevent version-only invocations from triggering first-run setup prompts and consuming telemetry first-run state.

Tests:
- Add integration tests ensuring version commands do not trigger OOBE or create telemetry installation markers.