### PR TITLE
Do not report None for `ruyi extract`'s into CWD

### DIFF
--- a/ruyi/ruyipkg/install.py
+++ b/ruyi/ruyipkg/install.py
@@ -156,10 +156,12 @@ def _do_extract_pkg(
         df.unpack(dest_dir, logger)
 
     if not fetch_only:
+        # None is the unpack helper's CWD sentinel; report it as a real path.
+        reported_dest_dir = pathlib.Path(".") if dest_dir is None else dest_dir
         logger.I(
             _("package [green]{pkg}[/] has been extracted to {dest_dir}").format(
                 pkg=pkg_name,
-                dest_dir=dest_dir,
+                dest_dir=reported_dest_dir,
             )
         )
 

--- a/tests/integration/test_cli_basic.py
+++ b/tests/integration/test_cli_basic.py
@@ -1,4 +1,10 @@
+import pytest
+
+from ruyi.ruyipkg.distfile import Distfile
 from tests.fixtures import IntegrationTestHarness
+
+
+SHA_STUB = "0" * 64
 
 
 def test_cli_version(ruyi_cli_runner: IntegrationTestHarness) -> None:
@@ -20,7 +26,6 @@ def test_cli_list_with_mock_repo(ruyi_cli_runner: IntegrationTestHarness) -> Non
 
 
 def test_cli_list_with_custom_package(ruyi_cli_runner: IntegrationTestHarness) -> None:
-    sha_stub = "1" * 64
     manifest = (
         'format = "v1"\n'
         'kind = ["source"]\n\n'
@@ -31,7 +36,7 @@ def test_cli_list_with_custom_package(ruyi_cli_runner: IntegrationTestHarness) -
         'name = "custom-src.tar.zst"\n'
         "size = 0\n\n"
         "[distfiles.checksums]\n"
-        f'sha256 = "{sha_stub}"\n'
+        f'sha256 = "{SHA_STUB}"\n'
     )
     ruyi_cli_runner.add_package("examples", "custom-cli", "0.1.0", manifest)
 
@@ -39,3 +44,51 @@ def test_cli_list_with_custom_package(ruyi_cli_runner: IntegrationTestHarness) -
 
     assert result.exit_code == 0
     assert "examples/custom-cli" in result.stdout
+
+
+def test_cli_extract_without_subdir_reports_current_directory(
+    ruyi_cli_runner: IntegrationTestHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = f"""\
+format = "v1"
+kind = ["source"]
+
+[metadata]
+desc = "Extract message package"
+vendor = {{ name = "Integration Tests", eula = "" }}
+
+[[distfiles]]
+name = "extract-src.raw"
+size = 0
+unpack = "raw"
+
+[distfiles.checksums]
+sha256 = "{SHA_STUB}"
+
+[source]
+distfiles = ["extract-src.raw"]
+"""
+    ruyi_cli_runner.add_package("examples", "extract-message", "1.0.0", manifest)
+
+    unpack_roots: list[object] = []
+
+    def fake_ensure(self: object, logger: object) -> None:
+        pass
+
+    def fake_unpack(self: object, root: object, logger: object) -> None:
+        unpack_roots.append(root)
+
+    monkeypatch.setattr(Distfile, "ensure", fake_ensure)
+    monkeypatch.setattr(Distfile, "unpack", fake_unpack)
+
+    result = ruyi_cli_runner(
+        "extract",
+        "--extract-without-subdir",
+        "examples/extract-message",
+    )
+
+    assert result.exit_code == 0
+    assert unpack_roots == [None]
+    assert "has been extracted to ." in result.stderr
+    assert "has been extracted to None" not in result.stderr


### PR DESCRIPTION
When `ruyi extract` runs without package subdirectories, the unpack helper keeps None as its current-directory sentinel. Translate that sentinel to '.' in the success message so the CLI reports the destination users asked for instead of leaking an implementation detail.

Fixes: #454

## Summary by Sourcery

Ensure `ruyi extract` reports a user-friendly current directory path instead of an internal sentinel when extracting without subdirectories.

Bug Fixes:
- Fix the extract command’s success message to show `.` for current-directory extractions rather than leaking a `None` implementation detail.

Tests:
- Add an integration test verifying that `ruyi extract --extract-without-subdir` reports extraction to `.` and not `None`.