### PR TITLE
Fix missing `_bz2` and `_lzma` extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,7 +470,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           registry: ghcr.io
-          image: ghcr.io/ruyisdk/ruyi-python-dist:20260423
+          image: ghcr.io/ruyisdk/ruyi-python-dist:20260622
           options: |
             --user root
             --platform linux/${{ matrix.arch }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -43,14 +43,14 @@ dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)"
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dist"]
 files = [
-    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
-    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
+    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
 
 [[package]]
@@ -767,18 +767,14 @@ files = [
 
 [[package]]
 name = "nuitka"
-version = "2.8.10"
+version = "4.1.3"
 description = "Python compiler with full language support and CPython compatibility"
 optional = false
 python-versions = "*"
 groups = ["dist"]
 files = [
-    {file = "nuitka-2.8.10.tar.gz", hash = "sha256:03e4d0756d8a11cb2627da3a2d9b518c802d031bf4f2c629e0a7b8c773497452"},
+    {file = "nuitka-4.1.3.tar.gz", hash = "sha256:838ff8899dc2f0b652d4fcf6c5d7466cb7ad5abcb005668ac622d1e40f4d8a8d"},
 ]
-
-[package.dependencies]
-ordered-set = ">=4.1.0"
-zstandard = ">=0.15"
 
 [package.extras]
 all = ["imageio", "setuptools (>=42)", "toml", "zstandard (>=0.15)"]
@@ -786,21 +782,6 @@ app = ["zstandard (>=0.15)"]
 build-wheel = ["setuptools (>=42)", "toml", "wheel"]
 icon-conversion = ["imageio"]
 onefile = ["zstandard (>=0.15)"]
-
-[[package]]
-name = "ordered-set"
-version = "4.1.0"
-description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
-optional = false
-python-versions = ">=3.7"
-groups = ["dist"]
-files = [
-    {file = "ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8"},
-    {file = "ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562"},
-]
-
-[package.extras]
-dev = ["black", "mypy", "pytest"]
 
 [[package]]
 name = "packaging"
@@ -1026,14 +1007,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
-    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -1359,7 +1340,7 @@ version = "0.25.0"
 description = "Zstandard bindings for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dist"]
+groups = ["main"]
 files = [
     {file = "zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd"},
     {file = "zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7"},
@@ -1468,4 +1449,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "c37554aefa3cc18d48ecede4ceeefd1b7a28c644f32f763be18cc9f9c58301c0"
+content-hash = "6d83c42de79983024170931251a3d1ae267ca09d092c1ecee0464c7b71f7a4f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ types-requests = "^2.31.0.20240311"
 
 [tool.poetry.group.dist.dependencies]
 certifi = "*"
-nuitka = "^2.0"
+nuitka = "^4"
 
 
 [tool.mypy]

--- a/ruyi/ruyipkg/unpack.py
+++ b/ruyi/ruyipkg/unpack.py
@@ -1,16 +1,11 @@
-import bz2
 from collections.abc import Generator
 from contextlib import contextmanager
-import gzip
-import lzma
 import mmap
 import os
 import shutil
 import subprocess
 from typing import Any, BinaryIO, NoReturn, Protocol
 
-import lz4.frame
-import zstandard
 
 from ..i18n import _
 from ..log import RuyiLogger
@@ -206,30 +201,40 @@ def open_decompressed(
 ) -> Generator[StreamReader, None, None]:
     match unpack_method:
         case UnpackMethod.TAR_GZ:
+            import gzip
+
             gzipFile = gzip.GzipFile(filename, "rb")
             try:
                 yield gzipFile
             finally:
                 gzipFile.close()
         case UnpackMethod.TAR_BZ2:
+            import bz2
+
             bz2File = bz2.BZ2File(filename, "rb")
             try:
                 yield bz2File
             finally:
                 bz2File.close()
         case UnpackMethod.TAR_XZ:
+            import lzma
+
             lzmaFile = lzma.LZMAFile(filename, "rb")
             try:
                 yield lzmaFile
             finally:
                 lzmaFile.close()
         case UnpackMethod.TAR_ZST:
+            import zstandard
+
             zstFile = zstandard.ZstdDecompressor().stream_reader(open(filename, "rb"))
             try:
                 yield zstFile
             finally:
                 zstFile.close()  # type: ignore[no-untyped-call]  # this is weird
         case UnpackMethod.TAR_LZ4:
+            import lz4.frame
+
             lz4File = lz4.frame.LZ4FrameFile(filename, "rb")
             try:
                 yield lz4File
@@ -250,30 +255,40 @@ def _wrap_decompressed(
         case UnpackMethod.TAR | UnpackMethod.TAR_AUTO:
             yield stream
         case UnpackMethod.TAR_GZ:
+            import gzip
+
             gzipFile = gzip.GzipFile(fileobj=stream, mode="rb")
             try:
                 yield gzipFile
             finally:
                 gzipFile.close()
         case UnpackMethod.TAR_BZ2:
+            import bz2
+
             bz2File = bz2.BZ2File(stream, "rb")
             try:
                 yield bz2File
             finally:
                 bz2File.close()
         case UnpackMethod.TAR_XZ:
+            import lzma
+
             lzmaFile = lzma.LZMAFile(stream, "rb")  # type: ignore[arg-type]  # in fact only read() is used
             try:
                 yield lzmaFile
             finally:
                 lzmaFile.close()
         case UnpackMethod.TAR_ZST:
+            import zstandard
+
             zstFile = zstandard.ZstdDecompressor().stream_reader(stream)  # type: ignore[arg-type]  # in fact only read() is used
             try:
                 yield zstFile
             finally:
                 zstFile.close()  # type: ignore[no-untyped-call]  # this is weird
         case UnpackMethod.TAR_LZ4:
+            import lz4.frame
+
             lz4File = lz4.frame.LZ4FrameFile(stream)
             try:
                 yield lz4File
@@ -314,6 +329,8 @@ def _do_unpack_bare_gz(
     if destdir is not None:
         os.chdir(destdir)
 
+    import gzip
+
     logger.D(f"decompressing gzip: {filename}")
     with gzip.open(filename, "rb") as src, open(dest_filename, "wb") as out:
         shutil.copyfileobj(src, out)
@@ -328,6 +345,8 @@ def _do_unpack_bare_bzip2(
 
     if destdir is not None:
         os.chdir(destdir)
+
+    import bz2
 
     logger.D(f"decompressing bzip2: {filename}")
     with bz2.open(filename, "rb") as src, open(dest_filename, "wb") as out:
@@ -344,6 +363,8 @@ def _do_unpack_bare_lz4(
     if destdir is not None:
         os.chdir(destdir)
 
+    import lz4.frame
+
     logger.D(f"decompressing lz4: {filename}")
     with lz4.frame.open(filename, "rb") as src, open(dest_filename, "wb") as out:
         shutil.copyfileobj(src, out)
@@ -359,6 +380,8 @@ def _do_unpack_bare_xz(
     if destdir is not None:
         os.chdir(destdir)
 
+    import lzma
+
     logger.D(f"decompressing xz: {filename}")
     with lzma.open(filename, "rb") as src, open(dest_filename, "wb") as out:
         shutil.copyfileobj(src, out)
@@ -373,6 +396,8 @@ def _do_unpack_bare_zstd(
 
     if destdir is not None:
         os.chdir(destdir)
+
+    import zstandard
 
     logger.D(f"decompressing zstd: {filename}")
     dctx = zstandard.ZstdDecompressor()

--- a/ruyi/ruyipkg/unpack.py
+++ b/ruyi/ruyipkg/unpack.py
@@ -281,11 +281,8 @@ def _wrap_decompressed(
         case UnpackMethod.TAR_ZST:
             import zstandard
 
-            zstFile = zstandard.ZstdDecompressor().stream_reader(stream)  # type: ignore[arg-type]  # in fact only read() is used
-            try:
+            with zstandard.ZstdDecompressor().stream_reader(stream) as zstFile:  # type: ignore[arg-type]  # in fact only read() is used
                 yield zstFile
-            finally:
-                zstFile.close()  # type: ignore[no-untyped-call]  # this is weird
         case UnpackMethod.TAR_LZ4:
             import lz4.frame
 

--- a/scripts/_image_tag_base.sh
+++ b/scripts/_image_tag_base.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # this file is meant to be sourced
 
-_COMMON_DIST_IMAGE_TAG="ghcr.io/ruyisdk/ruyi-python-dist:20260423"
+_COMMON_DIST_IMAGE_TAG="ghcr.io/ruyisdk/ruyi-python-dist:20260622"
 
 # Map of `uname -m` outputs to Debian arch name convention which Ruyi adopts
 #

--- a/scripts/dist-image/build-python.sh
+++ b/scripts/dist-image/build-python.sh
@@ -8,9 +8,7 @@ set -e
 #
 # See: https://github.com/Nuitka/Nuitka/commit/54f2a2222abedf92d45b8f397233cfb3bef340c5
 
-# Python 3.14.4 + Nuitka 2.8.10 produces ruyi binaries that segfault during
-# apply_config (ruyi init time)
-PYTHON_V=3.13.13
+PYTHON_V=3.14.6
 pushd /tmp
 wget "https://www.python.org/ftp/python/${PYTHON_V}/Python-${PYTHON_V}.tar.xz"
 mkdir py-src py-build

--- a/scripts/dist-image/prepare-distro.sh
+++ b/scripts/dist-image/prepare-distro.sh
@@ -108,6 +108,9 @@ EOF
         # Rust openssl-sys
         libssl-dev
         pkgconf
+        # python build: _bz2, _lzma extension modules
+        libbz2-dev
+        liblzma-dev
         # pygit2 build
         cmake
         wget
@@ -163,6 +166,9 @@ prepare_dnf_distro() {
         # Rust openssl-sys
         openssl-devel
         pkgconf-pkg-config
+        # python build: _bz2, _lzma extension modules
+        bzip2-devel
+        xz-devel
         # pygit2 build
         cmake
         wget

--- a/scripts/dist-image/prepare-poetry.sh
+++ b/scripts/dist-image/prepare-poetry.sh
@@ -5,18 +5,50 @@ set -e
 MAKEFLAGS="-j$(nproc)"
 export MAKEFLAGS
 
+_PIP_INSTALL=( pip install )
+
+# workaround too old rustc (1.81) when cryptography-49.0 has to be compiled,
+# with an MSRV of 1.83
+case "$(uname -m)" in
+riscv64)
+    wget https://static.rust-lang.org/rustup/dist/riscv64gc-unknown-linux-gnu/rustup-init
+    chmod a+x rustup-init
+    export RUSTUP_DIST_SERVER=https://mirrors.tuna.tsinghua.edu.cn/rustup/
+    ./rustup-init -y  # because there is already a system Rust
+    rustc -Vv
+    _PIP_INSTALL+=(
+        --prefer-binary
+        --extra-index-url https://gitlab.com/api/v4/projects/riseproject%2Fpython%2Fwheel_builder/packages/pypi/simple
+    )
+    ;;
+esac
+
+_pip_install() {
+    "${_PIP_INSTALL[@]}" "$@"
+}
+
 # poetry should be put into its own venv to avoid contaminating the dist build
 # venv; otherwise nuitka can and will see additional imports leading to bloat
-python3.13 -m venv /home/b/build-tools-venv
-/home/b/build-tools-venv/bin/pip install -U pip setuptools wheel
-/home/b/build-tools-venv/bin/pip install poetry
-/home/b/build-tools-venv/bin/pip install maturin==1.13.1 cibuildwheel~=3.4.1 auditwheel==6.6.0
+python3.14 -m venv /home/b/build-tools-venv
+# shellcheck disable=SC1091
+. /home/b/build-tools-venv/bin/activate
+hash -r
+_pip_install -U pip setuptools wheel
+_pip_install poetry
+_pip_install maturin==1.13.1 cibuildwheel~=3.4.1 auditwheel==6.6.0
+deactivate
+hash -r
 for tool in poetry maturin cibuildwheel auditwheel; do
     ln -s /home/b/build-tools-venv/bin/"$tool" /usr/local/bin/"$tool"
 done
 
-python3.13 -m venv /home/b/venv
-/home/b/venv/bin/pip install -U pip setuptools wheel
+python3.14 -m venv /home/b/venv
+# shellcheck disable=SC1091
+. /home/b/venv/bin/activate
+hash -r
+_pip_install -U pip setuptools wheel
+deactivate
+hash -r
 chown -R "$BUILDER_UID:$BUILDER_GID" /home/b/venv
 
 # remove wheel caches in the root user


### PR DESCRIPTION
## Summary by Sourcery

Ensure built Python distributions include compression extensions and update build tooling and base images accordingly.

Bug Fixes:
- Fix missing Python _bz2 and _lzma extension modules in built distributions by adding the required system libraries.

Enhancements:
- Upgrade the embedded Python version used for builds to 3.14.6 and bump Nuitka to the 4.x series.
- Improve riscv64 build robustness by adding a rustup-based Rust toolchain workaround and centralizing pip install options.
- Refine decompression handling in ruyipkg by importing compression libraries lazily and simplifying zstd stream management.

Build:
- Update distro preparation scripts to install the bzip2 and xz development packages needed for Python compression modules.
- Adjust Python virtualenv setup for build tools and runtime to use Python 3.14, with a shared pip install wrapper function.
- Refresh the common dist-image tag to point to the latest ruyi-python-dist container image.

CI:
- Update CI workflow to use the new ruyi-python-dist image tag for docker-based jobs.