### PR TITLE
Allow disabling the default `ruyisdk` repository

### DIFF
--- a/resources/po/zh_CN/LC_MESSAGES/ruyi.po
+++ b/resources/po/zh_CN/LC_MESSAGES/ruyi.po
@@ -92,21 +92,21 @@ msgstr "从 Ruyi 配置中移除一个章节"
 msgid "The section to remove"
 msgstr "要移除的章节"
 
-#: ruyi/cli/main.py:92
+#: ruyi/cli/main.py:91
 #, python-brace-format
 msgid "the {ruyi_exe} executable must be named [green]'{expected_name}'[/] to work"
 msgstr "{ruyi_exe} 可执行文件必须名为 [green]'{expected_name}'[/] 才能工作"
 
-#: ruyi/cli/main.py:99
+#: ruyi/cli/main.py:98
 #, python-brace-format
 msgid "it is now [yellow]'{current_name}'[/]"
 msgstr "当前为 [yellow]'{current_name}'[/]"
 
-#: ruyi/cli/main.py:103
+#: ruyi/cli/main.py:102
 msgid "please rename the command file and retry"
 msgstr "请给命令文件重命名后重试"
 
-#: ruyi/cli/main.py:165
+#: ruyi/cli/main.py:164
 msgid "internal error: CLI entrypoint was added without a telemetry key"
 msgstr "内部错误：CLI 入口点被添加时未附带遥测键"
 
@@ -352,37 +352,37 @@ msgstr ""
 msgid "This Ruyi installation is externally managed."
 msgstr "该 Ruyi 安装由外部管理。"
 
-#: ruyi/config/__init__.py:147
+#: ruyi/config/__init__.py:149
 #, python-brace-format
 msgid "the config key [yellow]{key}[/] cannot be set from user config; ignoring"
 msgstr "配置项 [yellow]{key}[/] 不能从用户配置文件被设置；忽略"
 
-#: ruyi/config/__init__.py:169
+#: ruyi/config/__init__.py:172
 #, python-brace-format
 msgid "the local repo path '{path}' is not absolute; ignoring"
 msgstr "本地仓库路径 '{path}' 不是绝对路径；忽略"
 
-#: ruyi/config/__init__.py:211
+#: ruyi/config/__init__.py:214
 #, python-brace-format
 msgid "ignoring \\[\\[repos]] entry with invalid id: '{id}'"
 msgstr "忽略具有无效 id 的 \\[\\[repos]] 条目：'{id}'"
 
-#: ruyi/config/__init__.py:220
+#: ruyi/config/__init__.py:223
 #, python-brace-format
 msgid "ignoring \\[\\[repos]] entry with reserved id '{id}'; use \\[repo] to configure the default repository"
 msgstr "忽略具有保留 id '{id}' 的 \\[\\[repos]] 条目；请使用 \\[repo] 来配置默认仓库"
 
-#: ruyi/config/__init__.py:228
+#: ruyi/config/__init__.py:261 ruyi/config/__init__.py:268
 #, python-brace-format
 msgid "ignoring duplicate \\[\\[repos]] entry with id '{id}'"
 msgstr "忽略具有重复 id '{id}' 的 \\[\\[repos]] 条目"
 
-#: ruyi/config/__init__.py:239
+#: ruyi/config/__init__.py:278
 #, python-brace-format
 msgid "ignoring \\[\\[repos]] entry '{id}': at least one of 'remote' or 'local' must be set"
 msgstr "忽略 \\[\\[repos]] 条目 '{id}'：'remote' 和 'local' 至少要设置一个"
 
-#: ruyi/config/__init__.py:248
+#: ruyi/config/__init__.py:287
 #, python-brace-format
 msgid "ignoring \\[\\[repos]] entry '{id}': the local path '{path}' is not absolute"
 msgstr "忽略 \\[\\[repos]] 条目 '{id}'：本地路径 '{path}' 不是绝对路径"
@@ -1840,54 +1840,54 @@ msgstr "{profile_id}（架构：[green]{arch}[/]，需要特殊特性：[yellow]
 msgid "unrecognized dist URL scheme: {scheme}"
 msgstr "未识别的分发 URL 协议：{scheme}"
 
-#: ruyi/ruyipkg/repo.py:437
+#: ruyi/ruyipkg/repo.py:435
 #, python-brace-format
 msgid "the package repository at [yellow]{root}[/] is not a valid Git repository"
 msgstr "位于 [yellow]{atom}[/] 的软件包仓库不是合法的 Git 仓库"
 
-#: ruyi/ruyipkg/repo.py:442
+#: ruyi/ruyipkg/repo.py:440
 msgid "it may be corrupt or left incomplete by an interrupted update"
 msgstr "可能由于某次更新被打断，造成该仓库损坏或不完整"
 
-#: ruyi/ruyipkg/repo.py:447
+#: ruyi/ruyipkg/repo.py:445
 #, python-brace-format
 msgid "please remove [yellow]{root}[/] and re-run [green]ruyi update[/]"
 msgstr "请将 [yellow]{root}[/] 移除，之后重新运行 [green]ruyi update[/]"
 
-#: ruyi/ruyipkg/repo.py:453
+#: ruyi/ruyipkg/repo.py:451
 #, python-brace-format
 msgid "the package repository does not exist at [yellow]{root}[/]"
 msgstr "软件包仓库不存在于 [yellow]{root}[/]"
 
-#: ruyi/ruyipkg/repo.py:458
+#: ruyi/ruyipkg/repo.py:456
 #, python-brace-format
 msgid "cloning from [cyan link={remote}]{remote}[/]"
 msgstr "正在从 [cyan link={remote}]{remote}[/] 克隆"
 
-#: ruyi/ruyipkg/repo.py:484
+#: ruyi/ruyipkg/repo.py:482
 #, python-brace-format
 msgid "skipping sync for local-only repo '{id}'"
 msgstr "为设置为仅本地的仓库 '{id}' 跳过同步"
 
-#: ruyi/ruyipkg/repo.py:492
+#: ruyi/ruyipkg/repo.py:490
 msgid "updating the package repository"
 msgstr "正在更新软件包仓库"
 
-#: ruyi/ruyipkg/repo.py:509
+#: ruyi/ruyipkg/repo.py:507
 msgid "package repository is updated"
 msgstr "软件包仓库已更新"
 
-#: ruyi/ruyipkg/repo.py:793
+#: ruyi/ruyipkg/repo.py:791
 #, python-brace-format
 msgid "UnicodeDecodeError: {path}"
 msgstr "Unicode 解码错误：{path}"
 
-#: ruyi/ruyipkg/repo.py:829
+#: ruyi/ruyipkg/repo.py:827
 #, python-brace-format
 msgid "unexpected return type of cmd plugin '{plugin_id}': {type} is not int."
 msgstr "命令插件 '{plugin_id}' 的返回类型非预期：{type} 不是 int。"
 
-#: ruyi/ruyipkg/repo.py:835
+#: ruyi/ruyipkg/repo.py:833
 msgid "forcing return code to 1; the plugin should be fixed"
 msgstr "强制返回码为 1；该插件需要被修复"
 
@@ -1978,8 +1978,8 @@ msgstr "无法移除默认仓库 '{id}'；请使用 'repo disable' 来禁用它"
 msgid "cannot remove system-provided repo '{id}'; use 'repo disable' instead"
 msgstr "无法移除由系统提供的仓库 '{id}'；请使用 'repo disable' 来禁用它"
 
-#: ruyi/ruyipkg/repo_cli.py:224 ruyi/ruyipkg/repo_cli.py:263
-#: ruyi/ruyipkg/repo_cli.py:296 ruyi/ruyipkg/repo_cli.py:331
+#: ruyi/ruyipkg/repo_cli.py:224 ruyi/ruyipkg/repo_cli.py:274
+#: ruyi/ruyipkg/repo_cli.py:333 ruyi/ruyipkg/repo_cli.py:370
 #, python-brace-format
 msgid "no repo with id '{id}' found in user config"
 msgstr "在用户配置中未找到 ID 为 '{id}' 的软件包仓库"
@@ -2002,37 +2002,37 @@ msgstr "启用一个软件包仓库"
 msgid "repository identifier to enable"
 msgstr "要启用的仓库的标识符"
 
-#: ruyi/ruyipkg/repo_cli.py:268
+#: ruyi/ruyipkg/repo_cli.py:271 ruyi/ruyipkg/repo_cli.py:279
 #, python-brace-format
 msgid "repo '{id}' enabled"
 msgstr "已启用软件包仓库 '{id}'"
 
-#: ruyi/ruyipkg/repo_cli.py:275
+#: ruyi/ruyipkg/repo_cli.py:286
 msgid "Disable a package repository"
 msgstr "禁用一个软件包仓库"
 
-#: ruyi/ruyipkg/repo_cli.py:279
+#: ruyi/ruyipkg/repo_cli.py:290
 msgid "repository identifier to disable"
 msgstr "要禁用的仓库的标识符"
 
-#: ruyi/ruyipkg/repo_cli.py:301
+#: ruyi/ruyipkg/repo_cli.py:340
 #, python-brace-format
 msgid "repo '{id}' disabled"
 msgstr "已禁用软件包仓库 '{id}'"
 
-#: ruyi/ruyipkg/repo_cli.py:308
+#: ruyi/ruyipkg/repo_cli.py:347
 msgid "Set the priority of a package repository"
 msgstr "为一个软件包仓库设置优先级"
 
-#: ruyi/ruyipkg/repo_cli.py:312
+#: ruyi/ruyipkg/repo_cli.py:351
 msgid "repository identifier"
 msgstr "软件包仓库标识符"
 
-#: ruyi/ruyipkg/repo_cli.py:317
+#: ruyi/ruyipkg/repo_cli.py:356
 msgid "new priority value"
 msgstr "新的优先级取值"
 
-#: ruyi/ruyipkg/repo_cli.py:337
+#: ruyi/ruyipkg/repo_cli.py:376
 #, python-brace-format
 msgid "repo '{id}' priority set to {priority}"
 msgstr "软件包仓库 '{id}' 的优先级已设置为 {priority}"

--- a/ruyi/cli/main.py
+++ b/ruyi/cli/main.py
@@ -19,7 +19,6 @@ ALLOWED_RUYI_ENTRYPOINT_NAMES: Final = (
     f"{RUYI_ENTRYPOINT_NAME}.exe",
     f"{RUYI_ENTRYPOINT_NAME}.bin",  # Nuitka one-file program cache
     "__main__.py",
-
     # Undocumented: for testing purposes only, to allow multiple versions of
     # ruyi to peacefully co-exist, while not allowing conflating the different
     # versions.

--- a/ruyi/config/__init__.py
+++ b/ruyi/config/__init__.py
@@ -73,6 +73,7 @@ class GlobalConfigRepoType(TypedDict):
     local: "NotRequired[str]"
     remote: "NotRequired[str]"
     branch: "NotRequired[str]"
+    disabled: "NotRequired[bool]"
 
 
 class GlobalConfigInstallationType(TypedDict):
@@ -130,6 +131,7 @@ class GlobalConfig:
         self._telemetry_upload_consent: datetime.datetime | None = None
         self._telemetry_pm_telemetry_url: str | None = None
 
+        self._repo_disabled = False
         self._extra_repo_entries: list["RepoEntry"] = []
 
     def _apply_config(
@@ -161,6 +163,7 @@ class GlobalConfig:
             self.override_repo_dir = repo_cfg.get(schema.KEY_REPO_LOCAL, None)
             self.override_repo_url = repo_cfg.get(schema.KEY_REPO_REMOTE, None)
             self.override_repo_branch = repo_cfg.get(schema.KEY_REPO_BRANCH, None)
+            self._repo_disabled = repo_cfg.get(schema.KEY_REPO_DISABLED, False)
 
             if self.override_repo_dir:
                 if not pathlib.Path(self.override_repo_dir).is_absolute():
@@ -224,12 +227,48 @@ class GlobalConfig:
                 continue
 
             if repo_id in seen_ids:
-                self.logger.W(
-                    _(r"ignoring duplicate \[\[repos]] entry with id '{id}'").format(
-                        id=repo_id
+                if not is_system:
+                    # A user-scope entry may override a system-scope entry by
+                    # merging user-supplied fields on top of the system defaults.
+                    for i, existing in enumerate(self._extra_repo_entries):
+                        if existing.id == repo_id and existing.is_system:
+                            self._extra_repo_entries[i] = RepoEntry(
+                                id=existing.id,
+                                name=entry_data.get(
+                                    schema.KEY_REPOS_NAME, existing.name
+                                ),
+                                remote=entry_data.get(
+                                    schema.KEY_REPOS_REMOTE, existing.remote or ""
+                                ),
+                                branch=entry_data.get(
+                                    schema.KEY_REPOS_BRANCH, existing.branch
+                                ),
+                                local_path=entry_data.get(
+                                    schema.KEY_REPOS_LOCAL, existing.local_path
+                                ),
+                                priority=entry_data.get(
+                                    schema.KEY_REPOS_PRIORITY, existing.priority
+                                ),
+                                active=entry_data.get(
+                                    schema.KEY_REPOS_ACTIVE, existing.active
+                                ),
+                                is_system=False,
+                            )
+                            break
+                    else:
+                        self.logger.W(
+                            _(
+                                r"ignoring duplicate \[\[repos]] entry with id '{id}'"
+                            ).format(id=repo_id)
+                        )
+                    continue
+                else:
+                    self.logger.W(
+                        _(
+                            r"ignoring duplicate \[\[repos]] entry with id '{id}'"
+                        ).format(id=repo_id)
                     )
-                )
-                continue
+                    continue
 
             remote = entry_data.get(schema.KEY_REPOS_REMOTE, "")
             local_path = entry_data.get(schema.KEY_REPOS_LOCAL, None)

--- a/ruyi/config/schema.py
+++ b/ruyi/config/schema.py
@@ -23,6 +23,7 @@ KEY_PACKAGES_PRERELEASES: Final = "prereleases"
 
 SECTION_REPO: Final = "repo"
 KEY_REPO_BRANCH: Final = "branch"
+KEY_REPO_DISABLED: Final = "disabled"
 KEY_REPO_LOCAL: Final = "local"
 KEY_REPO_REMOTE: Final = "remote"
 
@@ -88,6 +89,8 @@ def _get_expected_type_for_section_packages(sel: str) -> type:
 def _get_expected_type_for_section_repo(sel: str) -> type:
     if sel == KEY_REPO_BRANCH:
         return str
+    elif sel == KEY_REPO_DISABLED:
+        return bool
     elif sel == KEY_REPO_LOCAL:
         return str
     elif sel == KEY_REPO_REMOTE:

--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -424,9 +424,7 @@ class MetadataRepo(ProvidesPackageManifests):
                 if entries is not None and not entries:
                     # An empty directory is as-good-as-not-present: fall
                     # through to the clone path below to self-heal.
-                    self.logger.D(
-                        "repo dir exists but is empty; cloning afresh"
-                    )
+                    self.logger.D("repo dir exists but is empty; cloning afresh")
                 else:
                     # A non-empty but invalid directory. This is what a corrupt
                     # cache or a timeout-killed update looks like. We cannot

--- a/ruyi/ruyipkg/repo.py
+++ b/ruyi/ruyipkg/repo.py
@@ -87,7 +87,7 @@ class RepoEntry:
             branch=gc.override_repo_branch or DEFAULT_REPO_BRANCH,
             local_path=gc.override_repo_dir,
             priority=DEFAULT_REPO_PRIORITY,
-            active=True,
+            active=not gc._repo_disabled,
         )
 
     def make_metadata_repo(self, gc: "GlobalConfig") -> "MetadataRepo":

--- a/ruyi/ruyipkg/repo_cli.py
+++ b/ruyi/ruyipkg/repo_cli.py
@@ -253,12 +253,23 @@ class RepoEnableCommand(
     def main(cls, cfg: "GlobalConfig", args: argparse.Namespace) -> int:
         from ..config.editor import ConfigEditor
         from ..config.schema import KEY_REPOS_ACTIVE
+        from .repo import DEFAULT_REPO_ID
 
         logger = cfg.logger
         repo_id: str = args.id
 
         with ConfigEditor.work_on_user_local_config(cfg) as editor:
-            if not editor.update_repos_entry(repo_id, {KEY_REPOS_ACTIVE: True}):
+            if repo_id == DEFAULT_REPO_ID:
+                editor.unset_value("repo.disabled")
+            elif not editor.update_repos_entry(repo_id, {KEY_REPOS_ACTIVE: True}):
+                # Not in user config — if it exists as a system-provided repo,
+                # it is already active and nothing needs to be done.
+                for entry in cfg.repo_entries:
+                    if entry.id == repo_id and entry.is_system:
+                        # reuse the prompt to make the messages look uniform
+                        # regarding user-configured repos
+                        logger.I(_("repo '{id}' enabled").format(id=repo_id))
+                        return 0
                 logger.F(
                     _("no repo with id '{id}' found in user config").format(id=repo_id)
                 )
@@ -285,17 +296,45 @@ class RepoDisableCommand(
     @classmethod
     def main(cls, cfg: "GlobalConfig", args: argparse.Namespace) -> int:
         from ..config.editor import ConfigEditor
-        from ..config.schema import KEY_REPOS_ACTIVE
+        from ..config.schema import (
+            KEY_REPOS_ACTIVE,
+            KEY_REPOS_ID,
+            KEY_REPOS_LOCAL,
+            KEY_REPOS_NAME,
+            KEY_REPOS_REMOTE,
+        )
+        from .repo import DEFAULT_REPO_ID
 
         logger = cfg.logger
         repo_id: str = args.id
 
         with ConfigEditor.work_on_user_local_config(cfg) as editor:
-            if not editor.update_repos_entry(repo_id, {KEY_REPOS_ACTIVE: False}):
-                logger.F(
-                    _("no repo with id '{id}' found in user config").format(id=repo_id)
-                )
-                return 1
+            if repo_id == DEFAULT_REPO_ID:
+                editor.set_value("repo.disabled", True)
+            elif not editor.update_repos_entry(repo_id, {KEY_REPOS_ACTIVE: False}):
+                # Not in user config — might be a system-provided repo.
+                # Create a user [[repos]] entry to override the active flag.
+                for entry in cfg.repo_entries:
+                    if entry.id == repo_id and entry.is_system:
+                        entry_data: dict[str, object] = {
+                            KEY_REPOS_ID: repo_id,
+                            KEY_REPOS_ACTIVE: False,
+                        }
+                        if entry.remote:
+                            entry_data[KEY_REPOS_REMOTE] = entry.remote
+                        if entry.local_path:
+                            entry_data[KEY_REPOS_LOCAL] = entry.local_path
+                        if entry.name != repo_id:
+                            entry_data[KEY_REPOS_NAME] = entry.name
+                        editor.add_repos_entry(entry_data)
+                        break
+                else:
+                    logger.F(
+                        _("no repo with id '{id}' found in user config").format(
+                            id=repo_id
+                        )
+                    )
+                    return 1
             editor.stage()
 
         logger.I(_("repo '{id}' disabled").format(id=repo_id))

--- a/tests/config/test_repos_config.py
+++ b/tests/config/test_repos_config.py
@@ -290,3 +290,99 @@ class TestReposConfigParsing:
 
         entry = [e for e in gc.repo_entries if e.id == "disabled"][0]
         assert entry.active is False
+
+    def test_default_repo_disabled_via_config(
+        self,
+        mock_gm: "MockGlobalModeProvider",
+        ruyi_logger: "RuyiLogger",
+    ) -> None:
+        gc = GlobalConfig(mock_gm, ruyi_logger)
+        gc._apply_config(
+            {
+                "repo": {
+                    "disabled": True,
+                }
+            },
+            is_global_scope=False,
+        )
+        if "repo_entries" in gc.__dict__:
+            del gc.__dict__["repo_entries"]
+
+        default_entry = gc.repo_entries[0]
+        assert default_entry.id == "ruyisdk"
+        assert default_entry.active is False
+
+    def test_default_repo_disabled_then_enabled(
+        self,
+        mock_gm: "MockGlobalModeProvider",
+        ruyi_logger: "RuyiLogger",
+    ) -> None:
+        """Later configs override disabled; absence of the key means enabled."""
+        gc = GlobalConfig(mock_gm, ruyi_logger)
+        gc._apply_config(
+            {"repo": {"disabled": True}},
+            is_global_scope=False,
+        )
+        if "repo_entries" in gc.__dict__:
+            del gc.__dict__["repo_entries"]
+        assert gc.repo_entries[0].active is False
+
+        # A subsequent config without the disabled key re-enables
+        gc._apply_config(
+            {"repo": {"remote": "https://example.invalid/repo.git"}},
+            is_global_scope=False,
+        )
+        if "repo_entries" in gc.__dict__:
+            del gc.__dict__["repo_entries"]
+        assert gc.repo_entries[0].active is True
+
+    def test_system_repo_overridden_by_user_entry(
+        self,
+        mock_gm: "MockGlobalModeProvider",
+        ruyi_logger: "RuyiLogger",
+    ) -> None:
+        gc = GlobalConfig(mock_gm, ruyi_logger)
+
+        # A system-scope repo entry
+        gc._apply_config(
+            {
+                "repos": [
+                    {
+                        "id": "vendor-repo",
+                        "remote": "https://example.invalid/vendor.git",
+                        "priority": 10,
+                        "active": True,
+                    }
+                ]
+            },
+            is_global_scope=True,
+        )
+        if "repo_entries" in gc.__dict__:
+            del gc.__dict__["repo_entries"]
+
+        entries = gc.repo_entries
+        vendor = [e for e in entries if e.id == "vendor-repo"][0]
+        assert vendor.active is True
+        assert vendor.is_system is True
+
+        # A user-scope entry with same id should override the system entry
+        gc._apply_config(
+            {
+                "repos": [
+                    {
+                        "id": "vendor-repo",
+                        "active": False,
+                    }
+                ]
+            },
+            is_global_scope=False,
+        )
+        if "repo_entries" in gc.__dict__:
+            del gc.__dict__["repo_entries"]
+
+        entries = gc.repo_entries
+        vendor = [e for e in entries if e.id == "vendor-repo"][0]
+        assert vendor.active is False
+        assert vendor.is_system is False
+        # The remote should be preserved from the system entry
+        assert vendor.remote == "https://example.invalid/vendor.git"

--- a/tests/integration/test_multi_repo.py
+++ b/tests/integration/test_multi_repo.py
@@ -287,6 +287,52 @@ class TestRepoEnableDisable:
                 stripped = line.lstrip()
                 assert stripped.startswith("*")
 
+    def test_disable_default_repo(
+        self, ruyi_cli_runner: IntegrationTestHarness
+    ) -> None:
+        result = ruyi_cli_runner("repo", "disable", "ruyisdk")
+        assert result.exit_code == 0
+        assert "disabled" in result.stderr
+
+        result = ruyi_cli_runner("repo", "list")
+        lines = result.stdout.strip().splitlines()
+        for line in lines:
+            if "ruyisdk" in line:
+                stripped = line.lstrip()
+                assert not stripped.startswith("*"), (
+                    f"disabled default repo should not have *: {line}"
+                )
+
+    def test_enable_default_repo_after_disable(
+        self, ruyi_cli_runner: IntegrationTestHarness
+    ) -> None:
+        result = ruyi_cli_runner("repo", "disable", "ruyisdk")
+        assert result.exit_code == 0
+
+        result = ruyi_cli_runner("repo", "enable", "ruyisdk")
+        assert result.exit_code == 0
+        assert "enabled" in result.stderr
+
+        result = ruyi_cli_runner("repo", "list")
+        lines = result.stdout.strip().splitlines()
+        for line in lines:
+            if "ruyisdk" in line:
+                stripped = line.lstrip()
+                assert stripped.startswith("*"), (
+                    f"re-enabled default repo should have *: {line}"
+                )
+
+    def test_default_repo_disabled_excludes_packages(
+        self, ruyi_cli_runner: IntegrationTestHarness
+    ) -> None:
+        result = ruyi_cli_runner("repo", "disable", "ruyisdk")
+        assert result.exit_code == 0
+
+        result = ruyi_cli_runner("list", "--all")
+        assert result.exit_code == 0
+        # The sample-cli package from the default repo should no longer appear
+        assert "sample-cli" not in result.stdout
+
 
 class TestRepoSetPriority:
     """Set priority on repos via CLI."""


### PR DESCRIPTION
`ruyi repo remove ruyisdk` is still not possible at present without major refactoring (needs to deprecate the top-level `[repo]` section altogether to truly make the `ruyisdk` repo just another ordinary repository, only that it's auto-populated if absent. Should be enough for a better UX for #478 though to call it a fix.

## Summary by Sourcery

Allow the built-in ruyisdk repository to be disabled and re-enabled via configuration and CLI, and let user-scoped repo entries override system-provided ones.

New Features:
- Support disabling the default ruyisdk repository through config and repo CLI commands.
- Support re-enabling the default ruyisdk repository after it has been disabled.
- Allow user-scoped [[repos]] entries to override system-scoped entries while preserving defaults such as remote URL and paths.

Enhancements:
- Extend config schema with a boolean flag to control default repository activation state.
- Improve repo enable/disable CLI to handle system-provided repositories gracefully and create overriding user entries when needed.

Tests:
- Add unit tests for default repo disabled/enabled behavior and user override of system repo entries.
- Add integration tests to verify disabling/enabling the default repo via CLI and that disabled default repo packages are excluded from listings.